### PR TITLE
Add user settings to the user profile object

### DIFF
--- a/client/puzzle.css
+++ b/client/puzzle.css
@@ -226,6 +226,7 @@
     padding-right: 1em;
 }
 
-#toggle-shortcuts {
+.sidebar-link {
     font-size: 80%;
+    display: block;
 }

--- a/client/puzzle.js
+++ b/client/puzzle.js
@@ -174,11 +174,10 @@ function letter(keycode) {
     dc = 1;
   sq = find_blank_in_word(square, dr, dc);
   first = first_blank(selected_clue());
-  if (sq)
+  if (sq && Meteor.user().profile.settingWithinWord == "skip")
     select(sq);
-  else if (sq === null && first) {
-    select(first);
-  }
+  else if (sq === null && first && Meteor.user().profile.settingEndWordBack)
+      select(first);
   else if (Session.get('selected-direction') == 'across')
     move(0, 1, true);
   else
@@ -256,11 +255,15 @@ function handle_key(k) {
   }
   if (k.altKey || k.ctrlKey || k.metaKey)
     return true;
-  if ((k.keyCode === 39 || k.keyCode === 37) && Session.get('selected-direction') === 'down') {
+  if ((k.keyCode === 39 || k.keyCode === 37) &&
+      Session.get('selected-direction') === 'down' &&
+      Meteor.user().profile.settingArrows === "stay") { 
     Session.set('selected-direction', 'across');
     return false;
   }
-  else if ((k.keyCode === 38 || k.keyCode === 40) && Session.get('selected-direction') === 'across') {
+  else if ((k.keyCode === 38 || k.keyCode === 40) &&
+           Session.get('selected-direction') === 'across' &&
+           Meteor.user().profile.settingArrows === "stay") { 
     Session.set('selected-direction', 'down');
     return false;
   }

--- a/client/puzzle.js
+++ b/client/puzzle.js
@@ -230,7 +230,15 @@ function handle_key(k) {
   }
   if (k.altKey || k.ctrlKey || k.metaKey)
     return true;
-  if (k.keyCode === 39)
+  if ((k.keyCode === 39 || k.keyCode === 37) && Session.get('selected-direction') === 'down') {
+    Session.set('selected-direction', 'across');
+    return false;
+  }
+  else if ((k.keyCode === 38 || k.keyCode === 40) && Session.get('selected-direction') === 'across') {
+    Session.set('selected-direction', 'down');
+    return false;
+  }
+  else if (k.keyCode === 39)
     return move(0, 1);
   else if (k.keyCode === 37)
     return move(0, -1);

--- a/client/puzzle.js
+++ b/client/puzzle.js
@@ -174,9 +174,9 @@ function letter(keycode) {
     dc = 1;
   sq = find_blank_in_word(square, dr, dc);
   first = first_blank(selected_clue());
-  if (sq && Meteor.user().profile.settingWithinWord == "skip")
+  if (sq && Meteor.user() && Meteor.user().profile.settingWithinWord == "skip")
     select(sq);
-  else if (sq === null && first && Meteor.user().profile.settingEndWordBack)
+  else if (sq === null && first && Meteor.user() && Meteor.user().profile.settingEndWordBack)
       select(first);
   else if (Session.get('selected-direction') == 'across')
     move(0, 1, true);
@@ -257,12 +257,14 @@ function handle_key(k) {
     return true;
   if ((k.keyCode === 39 || k.keyCode === 37) &&
       Session.get('selected-direction') === 'down' &&
+      Meteor.user() &&
       Meteor.user().profile.settingArrows === "stay") { 
     Session.set('selected-direction', 'across');
     return false;
   }
   else if ((k.keyCode === 38 || k.keyCode === 40) &&
            Session.get('selected-direction') === 'across' &&
+           Meteor.user() &&
            Meteor.user().profile.settingArrows === "stay") { 
     Session.set('selected-direction', 'down');
     return false;

--- a/client/puzzle.js
+++ b/client/puzzle.js
@@ -137,12 +137,11 @@ function first_blank(word) {
   h['word_' + word.direction] = word.number;
   first = Squares.findOne(h);
   var dr = 0, dc = 0;
-  Session.get('selected-direction') === 'down' ? dr = 1 : dc = 1;
-  blanks = find_blank_in_word(first, dr, dc);
-  if (blanks)
-    return blanks;
+  if (Session.get('selected-direction') === 'down')
+    dr = 1;
   else
-    return false;
+    dc = 1;
+  return find_blank_in_word(first, dr, dc) || false;
 }
 
 function move(dr, dc, inword) {
@@ -172,12 +171,12 @@ function letter(keycode) {
     dr = 1;
   else
     dc = 1;
-  sq = find_blank_in_word(square, dr, dc);
-  first = first_blank(selected_clue());
+  var sq = find_blank_in_word(square, dr, dc);
+  var first = first_blank(selected_clue());
   if (sq && Meteor.user() && Meteor.user().profile.settingWithinWord == "skip")
     select(sq);
   else if (sq === null && first && Meteor.user() && Meteor.user().profile.settingEndWordBack)
-      select(first);
+    select(first);
   else if (Session.get('selected-direction') == 'across')
     move(0, 1, true);
   else
@@ -207,7 +206,7 @@ function find_blank_in_word(square, dr, dc) {
     if (s.black)
       return null;
     else if ((dc && (square.word_across !== s.word_across)) ||
-      (dr && (square.word_down !== s.word_down)))
+             (dr && (square.word_down !== s.word_down)))
       return false;
     var f = FillsBySquare.find({square: s._id, game: Session.get('gameid')});
     return f && f.letter === null;

--- a/client/puzzle.js
+++ b/client/puzzle.js
@@ -423,7 +423,15 @@ Template.controls.events({
   'click #toggle-shortcuts': function (e) {
     toggleKeyboardShortcuts();
     return false;
-  }
+  },
+  'change #settingsModal input': function (e) {
+    var inputName = $(e.currentTarget).attr("name");
+    // For radio inputs, this should return the one checked value. For checkbox inputs, this only
+    // works if there's exactly one checkbox with this name; this returns the checkbox's value as a
+    // string (if checked) or the bool false (if unchecked).
+    var inputValue = $("#settingsModal input[name='" + inputName + "']:checked").val() || false;
+    Meteor.call('updateSetting', inputName, inputValue);
+  },
 });
 
 Template.controls.helpers({
@@ -459,6 +467,22 @@ Template.controls.helpers({
       who.isMe = (who.user._id === Meteor.userId());
       return who;
     });
+  },
+  isSettingChecked: function(setting, value, isDefault) {
+    var curValue = Meteor.user().profile[setting];
+    // No setting defined yet (user hasn't visited the site since we added a new setting)
+    if (curValue === undefined) {
+      if (isDefault) {
+        // Set the user's setting to the default. This will set a value in the database for all
+        // radio inputs, and all default-checked checkboxes, but not for default-unchecked
+        // checkboxes. That's okay (getting the setting will return undefined instead of false,
+        // which is fine as long as we use truthiness checks everywhere), and the setting will get
+        // persisted to the database if you ever check the box.
+        Meteor.call('updateSetting', setting, value);
+      }
+      return isDefault ? "checked" : false;
+    }
+    return curValue == value ? "checked" : false;
   },
 });
 

--- a/client/sidebar.html
+++ b/client/sidebar.html
@@ -105,8 +105,11 @@
             <h5>At the end of a word:</h5>
             <label><input type="checkbox" name="settingEndWordBack" value="back" checked={{isSettingChecked 'settingEndWordBack' 'back' false}}>
             Jump back to first blank in the word (if any)</label><br>
+            <!--
+            // will add support for this. probably.
             <label><input type="checkbox" name="settingEndWordNext" value="next" checked={{isSettingChecked 'settingEndWordNext' 'next' false}}>
             Jump to the next clue (if not jumping back)</label><br>
+            -->
           </form>
         </div>
         <div class="modal-footer">

--- a/client/sidebar.html
+++ b/client/sidebar.html
@@ -91,19 +91,19 @@
         <div class="modal-body">
           <form class="form-inline">
             <h5>After changing direction with the arrow keys:</h5>
-            <label><input type="radio" name="settingArrows" value="stay" checked={{isSettingChecked 'settingArrows' 'stay' false}}>
+            <label><input type="radio" name="settingArrows" value="stay" checked={{isSettingChecked 'settingArrows' 'stay' true}}>
             Stay in the same square</label><br>
-            <label><input type="radio" name="settingArrows" value="move" checked={{isSettingChecked 'settingArrows' 'move' true}}>
+            <label><input type="radio" name="settingArrows" value="move" checked={{isSettingChecked 'settingArrows' 'move' false}}>
             Move in the direction of the arrow</label><br>
 
             <h5>Within a word:</h5>
-            <label><input type="radio" name="settingWithinWord" value="skip" checked={{isSettingChecked 'settingWithinWord' 'skip' false}}>
+            <label><input type="radio" name="settingWithinWord" value="skip" checked={{isSettingChecked 'settingWithinWord' 'skip' true}}>
             Skip over filled squares</label><br>
-            <label><input type="radio" name="settingWithinWord" value="overwrite" checked={{isSettingChecked 'settingWithinWord' 'overwrite' true}}>
+            <label><input type="radio" name="settingWithinWord" value="overwrite" checked={{isSettingChecked 'settingWithinWord' 'overwrite' false}}>
             Overwrite filled in squares</label><br>
 
             <h5>At the end of a word:</h5>
-            <label><input type="checkbox" name="settingEndWordBack" value="back" checked={{isSettingChecked 'settingEndWordBack' 'back' false}}>
+            <label><input type="checkbox" name="settingEndWordBack" value="back" checked={{isSettingChecked 'settingEndWordBack' 'back' true}}>
             Jump back to first blank in the word (if any)</label><br>
             <!--
             // will add support for this. probably.

--- a/client/sidebar.html
+++ b/client/sidebar.html
@@ -79,6 +79,7 @@
   </div>
   </div>
 
+  {{#if currentUser}}
   <a href="#" class="sidebar-link" id="toggle-settings" data-toggle="modal" data-target="#settingsModal">Settings</a>
   <div class="modal fade" id="settingsModal" tabindex="-1" role="dialog" aria-labelledby="settingsModalLabel">
     <div class="modal-dialog" role="document">
@@ -114,5 +115,7 @@
       </div>
     </div>
   </div>
+  {{else}}
+  {{/if}}
 
 </template>

--- a/client/sidebar.html
+++ b/client/sidebar.html
@@ -55,7 +55,7 @@
       </ul>
     </li>
   </ul>
-  <a href="#" id='toggle-shortcuts'>Keyboard Shortcuts</a>
+  <a href="#" class='sidebar-link' id='toggle-shortcuts'>Keyboard Shortcuts</a>
   <div id='shortcuts-help' style='display:none;'>
     <div class='contents'>
     <table>
@@ -78,4 +78,41 @@
     </table>
   </div>
   </div>
+
+  <a href="#" class="sidebar-link" id="toggle-settings" data-toggle="modal" data-target="#settingsModal">Settings</a>
+  <div class="modal fade" id="settingsModal" tabindex="-1" role="dialog" aria-labelledby="settingsModalLabel">
+    <div class="modal-dialog" role="document">
+      <div class="modal-content">
+        <div class="modal-header">
+          <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+          <h4 class="modal-title" id="settingsModalLabel">Solving settings</h4>
+        </div>
+        <div class="modal-body">
+          <form class="form-inline">
+            <h5>After changing direction with the arrow keys:</h5>
+            <label><input type="radio" name="settingArrows" value="stay" checked={{isSettingChecked 'settingArrows' 'stay' false}}>
+            Stay in the same square</label><br>
+            <label><input type="radio" name="settingArrows" value="move" checked={{isSettingChecked 'settingArrows' 'move' true}}>
+            Move in the direction of the arrow</label><br>
+
+            <h5>Within a word:</h5>
+            <label><input type="radio" name="settingWithinWord" value="skip" checked={{isSettingChecked 'settingWithinWord' 'skip' false}}>
+            Skip over filled squares</label><br>
+            <label><input type="radio" name="settingWithinWord" value="overwrite" checked={{isSettingChecked 'settingWithinWord' 'overwrite' true}}>
+            Overwrite filled in squares</label><br>
+
+            <h5>At the end of a word:</h5>
+            <label><input type="checkbox" name="settingEndWordBack" value="back" checked={{isSettingChecked 'settingEndWordBack' 'back' false}}>
+            Jump back to first blank in the word (if any)</label><br>
+            <label><input type="checkbox" name="settingEndWordNext" value="next" checked={{isSettingChecked 'settingEndWordNext' 'next' false}}>
+            Jump to the next clue (if not jumping back)</label><br>
+          </form>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+        </div>
+      </div>
+    </div>
+  </div>
+
 </template>

--- a/lib/game.js
+++ b/lib/game.js
@@ -128,5 +128,16 @@ Meteor.methods({
     check(Meteor.userId(), String);
     Meteor.users.update({_id: Meteor.userId()},
                         {$set: {'profile.name': name}});
-  }
+  },
+  'updateSetting': function (setting, value) {
+    check(Meteor.userId(), String);
+    // We want to set only this one profile setting (without overwriting the others). For some
+    // reason we get a compile-time error when trying to use a variable key in $set's dot notation
+    // inside the update call, but it works fine if we construct an object with a variable key
+    // before the update call.
+    var newProfile = {};
+    newProfile['profile.' + setting] = value;
+    Meteor.users.update({_id: Meteor.userId()},
+                        {$set: newProfile});
+  },
 });


### PR DESCRIPTION
Different users of this service have very different ideas of how they
want navigating through the grid to work, some with almost-religious
zeal. Rather than starting a holy war over the One True Way, let's
simply add per-user settings.

This commit adds a "Settings" link to the sidebar:
https://www.dropbox.com/scl/fi/otns69m88n6jnir8tkga8/Screenshot%202017-02-15%2015.10.51.png?dl=0

Clicking on "Settings" opens up a modal, currently with 4 settings:
https://www.dropbox.com/scl/fi/bit5ymgyekfhdfvmlunxe/Screenshot%202017-02-15%2015.10.57.png?dl=0

These settings are persisted in the `user.profile` object (along with
the user's name), so they apply to all puzzles solved by that user.