### PR TITLE
Set the keydown listener on window, instead of just the puzzle div

### DIFF
--- a/imports/components/puzzle.jsx
+++ b/imports/components/puzzle.jsx
@@ -86,6 +86,7 @@ class Puzzle extends React.Component {
   }
 
   componentDidMount() {
+    window.addEventListener('keydown', this.keyDown)
     this.div.focus();
   }
 
@@ -98,6 +99,7 @@ class Puzzle extends React.Component {
   }
 
   componentWillUnmount() {
+    window.removeEventListener('keydown', this.keyDown)
     this.stopSync();
   }
 
@@ -217,7 +219,6 @@ class Puzzle extends React.Component {
       */
       <div
         id="puzzle"
-        onKeyDown={this.keyDown}
         tabIndex="0"
         ref={(div) => { this.div = div; }}
       >


### PR DESCRIPTION
This ensures that Puzzle receives keydown events regardless of the
specific element that's currently in focus, which seems closer to the
desired behavior.

(Not sure if you had a different way in mind to wire this up)