### PR TITLE
Trim spaces from rebi

### DIFF
--- a/imports/components/puzzle_cell.jsx
+++ b/imports/components/puzzle_cell.jsx
@@ -9,7 +9,7 @@ class PuzzleCell extends React.PureComponent {
   constructor(props) {
     super(props);
     this.setSquare = (e) => {
-      this.props.delegate.setFill(this.props.square, e.target.value);
+      this.props.delegate.setFill(this.props.square, e.target.value.trim());
     };
   }
 


### PR DESCRIPTION
fixes #21 

I can't see any evidence of this happening in prod:
```
rs-ds027896:PRIMARY> db.fills.find({letter: /[^A-Z1-9]/}).limit(10)
rs-ds027896:PRIMARY>
```

But it's easy and seems obviously plausible.