### PR TITLE
Don't mark blank squares as checked

### DIFF
--- a/lib/game.js
+++ b/lib/game.js
@@ -62,6 +62,10 @@ function revealOne(square, fill) {
 }
 
 function checkOne(square, fill) {
+  if (!fill.letter) {
+    // Checking a blank square doesn't mark it wrong, but returning true will avoid selecting the blank square.
+    return true;
+  }
   if (fill.letter !== square.letter) {
     Fills.update({_id: fill._id},
                  { $set: {


### PR DESCRIPTION
Checking a partially-filled grid currently marks every blank square as wrong; it's not helpful to show those squares as wrong.

Instead, this just ignores blank squares when checking - they are marked neither correct nor wrong.