### PR TITLE
unbreak pencil/pen toggle hotkey on MacOS

### DIFF
--- a/imports/components/puzzle.jsx
+++ b/imports/components/puzzle.jsx
@@ -213,8 +213,11 @@ class Puzzle extends React.Component {
       return;
     }
 
-    if (e.altKey && e.key === 'p') {
+    // On MacOS, the altKey modifier has been applied to the key already
+    // before it gets sent to the keyDown, so 'p' is already 'π'.
+    if (e.altKey && (e.key === 'p' || e.key === 'π')) {
       this.delegate.togglePencil();
+      e.stopPropagation();
     }
 
     if (e.altKey || e.ctrlKey || e.metaKey) {


### PR DESCRIPTION
FWIW KeyboardEvent's code property [1] would be better suited to handle this
but it has no support on IE or Edge so it'd require a polyfill.

[1] https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/code

Fixes #27 