### PR TITLE
Implement the "Recent Games" menu

### DIFF
--- a/client/src/components/game_container.tsx
+++ b/client/src/components/game_container.tsx
@@ -4,6 +4,7 @@ import * as Types from "../types";
 import { PuzzleComponent } from "./puzzle";
 
 import { useClient, proto2Puzzle } from "../rpc";
+import { recordRecentGame } from "../recent_games";
 
 export interface GameContainerProps {
   gameId: string;
@@ -16,7 +17,16 @@ export const GameContainer = ({ gameId }: GameContainerProps) => {
     client.getGameById({ id: gameId }).then(
       (resp) => {
         if (resp.puzzle) {
-          setPuzzle(proto2Puzzle(resp.puzzle));
+          const puzzle = proto2Puzzle(resp.puzzle);
+          setPuzzle(puzzle);
+          // Every route into a game lands here, so this is the one place
+          // we need to remember it.
+          recordRecentGame({
+            gameId,
+            puzzleId: puzzle.id,
+            title: puzzle.title,
+            author: puzzle.author,
+          });
         }
       },
       (err) => {

--- a/client/src/components/header.tsx
+++ b/client/src/components/header.tsx
@@ -1,9 +1,9 @@
 import Container from "react-bootstrap/Container";
 import Navbar from "react-bootstrap/Navbar";
 import Nav from "react-bootstrap/Nav";
-import NavDropdown from "react-bootstrap/NavDropdown";
 
 import { NewGame } from "./new_game";
+import { RecentGames } from "./recent_games";
 
 export const Header = () => {
   return (
@@ -14,10 +14,7 @@ export const Header = () => {
         <Navbar.Collapse id="main-navbar">
           <Nav className="me-auto">
             <NewGame />
-            {/* Placeholder; the recent-games list is not implemented yet. */}
-            <NavDropdown title="Recent Games" id="recent-games-dropdown">
-              {null}
-            </NavDropdown>
+            <RecentGames />
           </Nav>
         </Navbar.Collapse>
       </Container>

--- a/client/src/components/recent_games.test.tsx
+++ b/client/src/components/recent_games.test.tsx
@@ -1,0 +1,58 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+
+import { RecentGames } from "./recent_games";
+import { recordRecentGame } from "../recent_games";
+
+function renderMenu() {
+  render(
+    <MemoryRouter>
+      <RecentGames />
+    </MemoryRouter>
+  );
+  fireEvent.click(screen.getByRole("button", { name: "Recent Games" }));
+}
+
+beforeEach(() => {
+  window.localStorage.clear();
+  window.dispatchEvent(new StorageEvent("storage", { key: null }));
+});
+
+it("lists recent games most-recent first", () => {
+  vi.useFakeTimers();
+  try {
+    vi.setSystemTime(1000);
+    recordRecentGame({
+      gameId: "game-1",
+      puzzleId: "puz-1",
+      title: "Monday Puzzle",
+      author: "Alice",
+    });
+    vi.setSystemTime(2000);
+    recordRecentGame({
+      gameId: "game-2",
+      puzzleId: "puz-2",
+      title: "Tuesday Puzzle",
+      author: "Bob",
+    });
+  } finally {
+    vi.useRealTimers();
+  }
+
+  renderMenu();
+
+  const links = screen.getAllByRole("link");
+  expect(links.map((l) => l.getAttribute("href"))).toEqual([
+    "/game/game-2",
+    "/game/game-1",
+  ]);
+  expect(links[0]).toHaveTextContent("Tuesday Puzzle");
+  expect(links[0]).toHaveTextContent("By Bob");
+});
+
+it("says so when there are no recent games", () => {
+  renderMenu();
+
+  expect(screen.getByText("No recent games")).toBeVisible();
+  expect(screen.queryAllByRole("link")).toEqual([]);
+});

--- a/client/src/components/recent_games.tsx
+++ b/client/src/components/recent_games.tsx
@@ -1,0 +1,41 @@
+import NavDropdown from "react-bootstrap/NavDropdown";
+
+import { Link } from "react-router";
+
+import { useRecentGames, type RecentGame } from "../recent_games";
+
+import "./style/recent_games.css";
+
+function formatPlayedAt(playedAt: number): string {
+  return new Date(playedAt).toLocaleDateString(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+}
+
+const RecentGameItem = ({ game }: { game: RecentGame }) => (
+  <NavDropdown.Item as={Link} to={`/game/${game.gameId}`}>
+    <div className="recent-game">
+      <span className="title">{game.title || "Untitled puzzle"}</span>
+      <span className="played-at">{formatPlayedAt(game.playedAt)}</span>
+    </div>
+    {game.author && <div className="author">By {game.author}</div>}
+  </NavDropdown.Item>
+);
+
+export const RecentGames = () => {
+  const games = useRecentGames();
+
+  return (
+    <NavDropdown title="Recent Games" id="recent-games-dropdown">
+      {games.length === 0 ? (
+        <NavDropdown.ItemText className="text-muted">
+          No recent games
+        </NavDropdown.ItemText>
+      ) : (
+        games.map((game) => <RecentGameItem key={game.gameId} game={game} />)
+      )}
+    </NavDropdown>
+  );
+};

--- a/client/src/components/style/recent_games.css
+++ b/client/src/components/style/recent_games.css
@@ -1,0 +1,21 @@
+#recent-games-dropdown + .dropdown-menu {
+  max-width: 22em;
+}
+
+#recent-games-dropdown + .dropdown-menu .recent-game {
+  display: flex;
+  gap: 1em;
+  justify-content: space-between;
+  align-items: baseline;
+}
+
+#recent-games-dropdown + .dropdown-menu .recent-game .title {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+#recent-games-dropdown + .dropdown-menu .recent-game .played-at,
+#recent-games-dropdown + .dropdown-menu .author {
+  font-size: 85%;
+  opacity: 0.7;
+}

--- a/client/src/recent_games.test.ts
+++ b/client/src/recent_games.test.ts
@@ -1,0 +1,98 @@
+import {
+  MAX_RECENT_GAMES,
+  getRecentGames,
+  recordRecentGame,
+} from "./recent_games";
+
+const STORAGE_KEY = "crossme.recent-games";
+
+// The store memoizes its parsed snapshot; a `storage` event is how it
+// learns that localStorage changed underneath it, so this stands in for
+// both a page reload and a write from another tab.
+function reloadFromStorage() {
+  window.dispatchEvent(new StorageEvent("storage", { key: STORAGE_KEY }));
+}
+
+function record(gameId: string, at: number) {
+  vi.setSystemTime(at);
+  recordRecentGame({
+    gameId,
+    puzzleId: `puzzle-${gameId}`,
+    title: `Puzzle ${gameId}`,
+    author: "Anonymous",
+  });
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  window.localStorage.clear();
+  reloadFromStorage();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+it("returns games most-recent first", () => {
+  record("a", 1000);
+  record("b", 3000);
+  record("c", 2000);
+
+  expect(getRecentGames().map((g) => g.gameId)).toEqual(["b", "c", "a"]);
+});
+
+it("records the metadata needed to render the menu", () => {
+  record("a", 1000);
+
+  expect(getRecentGames()).toEqual([
+    {
+      gameId: "a",
+      puzzleId: "puzzle-a",
+      title: "Puzzle a",
+      author: "Anonymous",
+      playedAt: 1000,
+    },
+  ]);
+});
+
+it("moves a re-opened game to the front without duplicating it", () => {
+  record("a", 1000);
+  record("b", 2000);
+  record("a", 3000);
+
+  const games = getRecentGames();
+  expect(games.map((g) => g.gameId)).toEqual(["a", "b"]);
+  expect(games[0].playedAt).toEqual(3000);
+});
+
+it("remembers a fixed number of games", () => {
+  for (let i = 0; i < MAX_RECENT_GAMES + 5; i++) {
+    record(`game-${i}`, 1000 * (i + 1));
+  }
+
+  const games = getRecentGames();
+  expect(games).toHaveLength(MAX_RECENT_GAMES);
+  expect(games[0].gameId).toEqual(`game-${MAX_RECENT_GAMES + 4}`);
+  expect(games[games.length - 1].gameId).toEqual("game-5");
+});
+
+it("persists across reloads", () => {
+  record("a", 1000);
+  record("b", 2000);
+  reloadFromStorage();
+
+  expect(getRecentGames().map((g) => g.gameId)).toEqual(["b", "a"]);
+});
+
+it("ignores junk in storage", () => {
+  window.localStorage.setItem(STORAGE_KEY, "not json at all");
+  reloadFromStorage();
+  expect(getRecentGames()).toEqual([]);
+
+  window.localStorage.setItem(
+    STORAGE_KEY,
+    JSON.stringify([{ gameId: "a", playedAt: 1 }, "nope"])
+  );
+  reloadFromStorage();
+  expect(getRecentGames()).toEqual([]);
+});

--- a/client/src/recent_games.ts
+++ b/client/src/recent_games.ts
@@ -1,0 +1,116 @@
+import { useSyncExternalStore } from "react";
+
+// The list of recently-played games lives entirely in the browser; the
+// server has no notion of a user identity, so "your" games are just the
+// ones this browser has opened.
+
+const STORAGE_KEY = "crossme.recent-games";
+
+// How many games we remember. Older entries are dropped.
+export const MAX_RECENT_GAMES = 10;
+
+export interface RecentGame {
+  gameId: string;
+  puzzleId: string;
+  title: string;
+  author: string;
+  // Epoch milliseconds when this game was last opened.
+  playedAt: number;
+}
+
+function isRecentGame(value: unknown): value is RecentGame {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+  const game = value as Record<string, unknown>;
+  return (
+    typeof game.gameId === "string" &&
+    game.gameId !== "" &&
+    typeof game.puzzleId === "string" &&
+    typeof game.title === "string" &&
+    typeof game.author === "string" &&
+    typeof game.playedAt === "number" &&
+    Number.isFinite(game.playedAt)
+  );
+}
+
+// Sorted most-recent first. Entries written by an older (or corrupt)
+// version of the app are dropped rather than crashing the header.
+function readStorage(): RecentGame[] {
+  let parsed: unknown;
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) {
+      return [];
+    }
+    parsed = JSON.parse(raw);
+  } catch {
+    // Storage can be unavailable entirely (private browsing, disabled
+    // cookies), or hold something that isn't valid JSON. Recent games
+    // are a convenience; just do without.
+    return [];
+  }
+  if (!Array.isArray(parsed)) {
+    return [];
+  }
+  return parsed
+    .filter(isRecentGame)
+    .sort((a, b) => b.playedAt - a.playedAt)
+    .slice(0, MAX_RECENT_GAMES);
+}
+
+function writeStorage(games: RecentGame[]) {
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(games));
+  } catch {
+    // See readStorage.
+  }
+}
+
+// `useSyncExternalStore` requires a stable snapshot, so we cache the
+// parsed list and invalidate it whenever the underlying storage changes.
+let cache: null | RecentGame[] = null;
+const listeners = new Set<() => void>();
+
+function invalidate() {
+  cache = null;
+  for (const listener of listeners) {
+    listener();
+  }
+}
+
+// `storage` fires for writes made by *other* tabs, which lets every open
+// tab share one list.
+window.addEventListener("storage", (ev) => {
+  if (ev.key === null || ev.key === STORAGE_KEY) {
+    invalidate();
+  }
+});
+
+function subscribe(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+export function getRecentGames(): RecentGame[] {
+  if (cache === null) {
+    cache = readStorage();
+  }
+  return cache;
+}
+
+export function recordRecentGame(game: Omit<RecentGame, "playedAt">) {
+  const entry: RecentGame = { ...game, playedAt: Date.now() };
+  const games = [
+    entry,
+    ...getRecentGames().filter((g) => g.gameId !== entry.gameId),
+  ].slice(0, MAX_RECENT_GAMES);
+  writeStorage(games);
+  invalidate();
+}
+
+export function useRecentGames(): RecentGame[] {
+  return useSyncExternalStore(subscribe, getRecentGames);
+}


### PR DESCRIPTION
Remember the games this browser has opened in localStorage, and list them, most-recent first, in the header dropdown that was previously a placeholder. The server has no notion of user identity, so the list is purely client-side; we keep a fixed ten entries and drop the oldest.

Games are recorded in GameContainer, which every route into a game passes through. The store exposes a `useSyncExternalStore` hook so the menu updates as soon as a game is opened, including from another tab.