### PR TITLE
Modernize the Dockerfiles for production

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,7 @@
+.git/
+.github/
 bin/
 client/
-maria/
+data/
+docs/
+*.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,7 @@
 # CrossMe -- A realtime collaborate crossword-puzzle app
 
 - See @ARCHITECTURE.md for details on the application's high-level architecture. All changes must be in line with this architecture; any changes which go against or alter this architecture require explicit human approval.
+
+## Deployment status
+
+- As of this note, crossme is **not deployed**. We can make backwards-incompatible changes to the data schema or deployment tooling without any impact. Flag any such changes to the user, but be willing to make them if it makes sense.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,7 @@
 
 - See @ARCHITECTURE.md for details on the application's high-level architecture. All changes must be in line with this architecture; any changes which go against or alter this architecture require explicit human approval.
 
-## Deployment status
+## Instructions
 
 - As of this note, crossme is **not deployed**. We can make backwards-incompatible changes to the data schema or deployment tooling without any impact. Flag any such changes to the user, but be willing to make them if it makes sense.
+- Commit your work. Commit your work after each completed unit of work. If you've completed a logical chunk of work and are returning control to the user, and you are not asking a substantial design question or direction about how to complete the current task, you should probably have made a commit.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,53 @@
-FROM golang:alpine
-ADD . /crossme
-WORKDIR /crossme
-RUN mkdir bin && env GOBIN=/crossme/bin go install ./cmd/...
+# syntax=docker/dockerfile:1
 
-FROM alpine
-RUN mkdir -p /crossme/bin/
-COPY --from=0 /crossme/bin /crossme/bin
+# Keep GO_VERSION in sync with go.mod. The builder and the runtime pin the same
+# Alpine release so the cgo build and the runtime agree on musl.
+ARG GO_VERSION=1.25
+ARG ALPINE_VERSION=3.22
+
+FROM golang:${GO_VERSION}-alpine${ALPINE_VERSION} AS build
+
+# github.com/mattn/go-sqlite3 is a cgo package, so we need a C toolchain.
+RUN apk add --no-cache build-base
+
+WORKDIR /src
+
+# Download modules in their own layer so editing source doesn't refetch them.
+COPY go.mod go.sum ./
+RUN --mount=type=cache,target=/go/pkg/mod \
+    go mod download
+
+COPY . .
+
+# Link statically so the resulting binaries don't care what's in the runtime
+# image. sqlite_omit_load_extension drops sqlite's extension loader, which we
+# never use and don't want to expose.
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    CGO_ENABLED=1 go build \
+      -trimpath \
+      -tags sqlite_omit_load_extension \
+      -ldflags '-s -w -extldflags "-static"' \
+      -o /out/ ./cmd/...
+
+FROM alpine:${ALPINE_VERSION}
+
+RUN apk add --no-cache ca-certificates tzdata \
+ && adduser -S -D -H -u 10001 crossme \
+ && mkdir -p /data \
+ && chown crossme /data
+
+COPY --from=build /out/crossme /out/crossme-build-db /usr/local/bin/
+
+# The sqlite database lives here; mount a volume over it to make it durable.
+VOLUME /data
+USER crossme
+EXPOSE 4000
+
+# wget exits 8 when the server returns an HTTP error; the Connect handler 404s
+# on a bare GET, so either a success or an 8 means we're serving.
+HEALTHCHECK --interval=30s --timeout=3s --start-period=5s \
+  CMD wget -q -O /dev/null http://127.0.0.1:4000/api/ || [ "$?" = 8 ]
+
+ENTRYPOINT ["crossme"]
+CMD ["-bind", "0.0.0.0:4000", "-db", "/data/crossme.db"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,10 +44,8 @@ VOLUME /data
 USER crossme
 EXPOSE 4000
 
-# wget exits 8 when the server returns an HTTP error; the Connect handler 404s
-# on a bare GET, so either a success or an 8 means we're serving.
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s \
-  CMD wget -q -O /dev/null http://127.0.0.1:4000/api/ || [ "$?" = 8 ]
+  CMD wget -q -O /dev/null http://127.0.0.1:4000/healthz
 
 ENTRYPOINT ["crossme"]
 CMD ["-bind", "0.0.0.0:4000", "-db", "/data/crossme.db"]

--- a/client/.dockerignore
+++ b/client/.dockerignore
@@ -1,2 +1,6 @@
+.git/
 node_modules/
 dist/
+coverage/
+Dockerfile
+.dockerignore

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -1,11 +1,33 @@
-FROM node:22-alpine AS build
+# syntax=docker/dockerfile:1
 
-WORKDIR /crossme
-COPY package*.json ./
-RUN npm ci
+ARG NODE_VERSION=24
+ARG NGINX_VERSION=1.29
+
+FROM node:${NODE_VERSION}-alpine AS build
+
+WORKDIR /src
+
+# Install dependencies in their own layer, keyed only on the lockfile.
+COPY package.json package-lock.json ./
+RUN --mount=type=cache,target=/root/.npm \
+    npm ci
+
 COPY . .
 RUN npm run build
 
-FROM nginx
-ADD nginx.conf /etc/nginx/nginx.conf
-COPY --from=build /crossme/dist /crossme/dist
+FROM nginx:${NGINX_VERSION}-alpine
+
+COPY nginx.conf /etc/nginx/nginx.conf
+COPY --from=build /src/dist /crossme/dist
+
+# Run the master process unprivileged too, not just the workers. nginx.conf
+# points its pid and every temp path at /tmp, so nothing should land in
+# /var/cache/nginx; chowning it anyway keeps a missed directive from turning
+# into a permission error at startup.
+RUN chown -R nginx:nginx /var/cache/nginx
+
+USER nginx
+EXPOSE 8080
+
+HEALTHCHECK --interval=30s --timeout=3s --start-period=5s \
+  CMD wget -q -O /dev/null http://127.0.0.1:8080/healthz

--- a/client/nginx.conf
+++ b/client/nginx.conf
@@ -1,8 +1,10 @@
-user nginx;
-worker_processes  1;
+# No `user` directive: we run the master as the unprivileged `nginx` user, and
+# setting it would only produce a warning. Everything nginx writes has to live
+# somewhere that user owns, hence the pid and temp paths below.
+worker_processes auto;
 
 error_log  /dev/stdout warn;
-pid        /var/run/nginx.pid;
+pid        /tmp/nginx.pid;
 
 events {
     worker_connections  1024;
@@ -18,30 +20,68 @@ http {
 
     access_log  /dev/stdout  main;
 
+    client_body_temp_path /tmp/client_temp;
+    proxy_temp_path       /tmp/proxy_temp;
+    fastcgi_temp_path     /tmp/fastcgi_temp;
+    uwsgi_temp_path       /tmp/uwsgi_temp;
+    scgi_temp_path        /tmp/scgi_temp;
+
     sendfile        on;
-    #tcp_nopush     on;
+    tcp_nopush      on;
+    server_tokens   off;
 
     keepalive_timeout  65;
 
-    #gzip  on;
+    gzip              on;
+    gzip_vary         on;
+    gzip_proxied      any;
+    gzip_min_length   1024;
+    gzip_types        text/plain text/css application/javascript
+                      application/json image/svg+xml application/wasm;
 
-
-    # Vite emits content-hashed filenames under /assets/.
+    # Vite emits content-hashed filenames under /assets/, so those are
+    # immutable. Everything else (chiefly index.html) must be revalidated so a
+    # deploy doesn't strand clients on a stale app shell.
     map $uri $cache {
-      default none;
+      default no-cache;
       ~^/assets/ max-age=31536000,immutable;
     }
 
     server {
-      listen [::]:80 default ipv6only=off;
+      # 8080, not 80: an unprivileged process can't bind a low port on every
+      # platform we might land on. Publish it as :80 at the container boundary.
+      listen [::]:8080 default ipv6only=off;
 
       root /crossme/dist/;
       charset utf-8;
+
+      # These live at the server level, and no location below sets its own
+      # add_header: a location that did would drop all of these, since nginx
+      # only inherits add_header when the child block has none of its own.
+      #
+      # We serve our own JS and talk only to our own API; lock the page down
+      # to that. 'unsafe-inline' is needed for react-select/bootstrap's
+      # injected styles.
+      add_header Content-Security-Policy "default-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'" always;
+      add_header X-Content-Type-Options nosniff always;
+      add_header Referrer-Policy same-origin always;
+      add_header Cache-Control $cache always;
+
+      # Liveness probe; deliberately not proxied to the API.
+      location = /healthz {
+        access_log off;
+        default_type text/plain;
+        return 200 "ok\n";
+      }
 
       location /api/ {
         # The Go server speaks the Connect protocol directly.
         proxy_pass http://crossme-api:4000/api/;
         proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
         # Subscribe is a server-streaming RPC; nginx must not buffer it.
         proxy_buffering off;
         proxy_read_timeout 1h;
@@ -49,8 +89,6 @@ http {
 
       location / {
         try_files $uri $uri/ /index.html;
-
-        add_header Cache-Control $cache;
       }
     }
 }

--- a/cmd/crossme/main.go
+++ b/cmd/crossme/main.go
@@ -1,9 +1,12 @@
 package main
 
 import (
+	"context"
 	"flag"
+	"io"
 	"log"
 	"net/http"
+	"time"
 
 	"crossme.app/src/pb/pbconnect"
 	"crossme.app/src/repo"
@@ -27,6 +30,23 @@ func main() {
 	srv := server.New(r)
 
 	mux := http.NewServeMux()
+
+	// Health check for the container runtime. It lives outside /api/ so nginx
+	// doesn't expose it, and it touches the database so that a server which
+	// has lost its sqlite file reports unhealthy instead of merely accepting
+	// connections.
+	mux.HandleFunc("GET /healthz", func(w http.ResponseWriter, req *http.Request) {
+		ctx, cancel := context.WithTimeout(req.Context(), 2*time.Second)
+		defer cancel()
+		if err := r.Ping(ctx); err != nil {
+			log.Printf("healthz: %v", err)
+			http.Error(w, "database unavailable", http.StatusServiceUnavailable)
+			return
+		}
+		w.Header().Set("Content-Type", "text/plain")
+		io.WriteString(w, "ok\n")
+	})
+
 	path, handler := pbconnect.NewCrossMeHandler(srv)
 	// The web client reaches us under /api/, both through the vite dev
 	// server and through nginx in production.

--- a/repo/repo.go
+++ b/repo/repo.go
@@ -1,6 +1,7 @@
 package repo
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"net/url"
@@ -67,6 +68,12 @@ func (r *Repository) init() error {
 	}
 
 	return nil
+}
+
+// Ping checks that the database is still usable. It's meant for health
+// checks, not for use on the request path.
+func (r *Repository) Ping(ctx context.Context) error {
+	return r.db.PingContext(ctx)
 }
 
 func (r *Repository) Close() error {


### PR DESCRIPTION
The server image never actually built: `repo` imports `mattn/go-sqlite3`, which is cgo, and `golang:alpine` ships no C toolchain. It also had no entrypoint, and baked `data/crossme.db` into the image because `.dockerignore` didn't exclude it.

## Both images

- Pinned bases (`golang:1.25-alpine3.22`, `alpine:3.22`, `node:24-alpine`, `nginx:1.29-alpine`) behind `ARG`s, instead of floating tags.
- Dependency installation split into its own layer keyed on the lockfile, with BuildKit cache mounts.
- Run as an unprivileged user.

## Server

- `build-base` in the builder so the cgo build works at all.
- Static link plus `-trimpath` and `-tags sqlite_omit_load_extension`, so the binaries don't care about the runtime image and sqlite's extension loader is gone.
- `/data` volume for the sqlite file, `ENTRYPOINT`/`CMD` with flags that work in a container (the defaults bind `localhost` and put the database at `/crossme:`).
- New `GET /healthz` that pings sqlite, so a server that has lost its database reports unhealthy rather than merely reachable. It sits outside `/api/`, so nginx never proxies it out.

## Client / nginx

- nginx runs fully unprivileged: no `user` directive, pid and all temp paths under `/tmp`, listening on 8080. Publish it as `-p 80:8080`.
- gzip, CSP + `X-Content-Type-Options` + `Referrer-Policy`, a `/healthz` probe, and the usual `X-Forwarded-*` headers.
- `Cache-Control` moves up to the server block. As the lone `add_header` in `location /` it would have suppressed every inherited security header on exactly the HTML that needs them. The map default also changes from `none` (not a real directive) to `no-cache`, so a deploy can't strand clients on a stale app shell.

## Testing

`go build`, `go vet`, `gofmt`, and `go test ./...` all pass, and I exercised `/healthz` against a locally-run server (200 `ok`; 405 on POST). The 503 branch is unexercised.

**Neither image has been built** — docker isn't available in the environment I worked in, so the musl static link, the `golang:1.25-alpine3.22` tag, and `nginx -t` on the new config are all unverified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)