### PR TITLE
Implement database schema migrations system

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -10,6 +10,8 @@ The backend is implemented in Go, and the frontend communicates with it via [con
 
 The server stores data using sqlite. All direct interaction with the SQL database is managed via the `Repo` type, exported from the `repo` top-level package. Data is stored in the database primarily as encoded protobuf objects in `blob` columns, with a small number of fields replicated as SQL columns for efficient indexing or querying.
 
+The SQL schema is defined by an ordered list of migrations in `repo/migrate.go`; `migrations[i]` upgrades the database from schema version `i` to version `i+1`, so the current schema version is just the number of migrations. The database records its own version in the `Config` proto stored in the `config` table, which is the one piece of schema created outside the migration sequence. Opening a database plays any missing migrations forward, each in a transaction that also stamps the new version; opening a database from the future is an error. Migrations are append-only: changing the schema means adding a migration, not editing an existing one.
+
 Durable state is committed to the SQL database. Transient state about current connections and live games lives in-memory in the server. If the server restarts, we assume clients will reconnect if necessary. The server is assumed to be a single instance of the Go server process; there is no support for running across multiple processes or nodes.
 
 ## The "Game" CRDT

--- a/repo/migrate.go
+++ b/repo/migrate.go
@@ -1,0 +1,158 @@
+package repo
+
+import (
+	"database/sql"
+	"fmt"
+
+	"github.com/jmoiron/sqlx"
+	"google.golang.org/protobuf/proto"
+
+	"crossme.app/src/pb"
+)
+
+// The config table holds the schema version, so it has to exist before we
+// can decide which migrations to run. It is created (idempotently) on every
+// open, outside of the migration sequence.
+const sql_create_config = `
+CREATE TABLE IF NOT EXISTS config (
+  id int primary key not null,
+  proto blob not null
+) strict;
+`
+
+const sql_write_config = `REPLACE INTO config (id, proto) VALUES(0, ?)`
+
+// A migration upgrades the database schema by a single version. Applying
+// migrations[i] moves the database from schema version i to version i+1;
+// each one runs exactly once, in its own transaction, together with the
+// config update that records the new version.
+type migration struct {
+	name string
+	sql  string
+}
+
+// migrations is append-only: once a migration has shipped, edit it only to
+// fix something that has never run anywhere. Adding a new one is the way to
+// change the schema.
+var migrations = []migration{
+	{
+		name: "initial-schema",
+		sql: `
+CREATE TABLE puzzles (
+  proto blob not null,
+  title text not null,
+  meta__sha256 text null unique,
+  meta__id text unique not null primary key,
+  meta__date text not null,
+  meta__created text not null
+) strict;
+
+CREATE INDEX puzzles__date ON puzzles (meta__date);
+
+CREATE TABLE games (
+  proto blob not null,
+  id text not null unique primary key,
+  puzzle_id text not null,
+  created text not null
+) strict;
+
+CREATE TABLE puz_files (
+  sha256 text unique primary key,
+  file blob
+) strict;
+`,
+	},
+	{
+		name: "games-completed-at",
+		sql: `
+ALTER TABLE games ADD COLUMN completed_at text null;
+`,
+	},
+}
+
+// CurrentSchemaVersion is the schema version this build expects. A database
+// below it is migrated forward on open; a database above it is refused.
+var CurrentSchemaVersion = int32(len(migrations))
+
+// loadConfig reads the stored config, creating the config table if this is a
+// brand-new database. A database with no config row is treated as version 0,
+// i.e. entirely unmigrated.
+func (r *Repository) loadConfig() error {
+	if _, err := r.db.Exec(sql_create_config); err != nil {
+		return fmt.Errorf("creating config table: %w", err)
+	}
+	var config_bytes []byte
+	if err := r.db.Get(&config_bytes, "SELECT proto FROM config LIMIT 1"); err != nil {
+		if err != sql.ErrNoRows {
+			return fmt.Errorf("error loading config: %w", err)
+		}
+	}
+	if config_bytes != nil {
+		if err := proto.Unmarshal(config_bytes, &r.Config); err != nil {
+			return fmt.Errorf("error parsing config: %w", err)
+		}
+	}
+	return nil
+}
+
+// migrate plays migrations forward until the database is at `target`. It is
+// a no-op if the database is already there.
+func (r *Repository) migrate(target int32) error {
+	if target < 0 || target > CurrentSchemaVersion {
+		return fmt.Errorf("no such schema version: %d", target)
+	}
+	version := r.Config.SchemaVersion
+	if version > CurrentSchemaVersion {
+		return fmt.Errorf(
+			"database is at schema version %d, but this build only knows about version %d; upgrade crossme",
+			version, CurrentSchemaVersion)
+	}
+	if version > target {
+		return fmt.Errorf(
+			"database is at schema version %d; migrating down to %d is not supported",
+			version, target)
+	}
+	for version < target {
+		m := &migrations[version]
+		if err := r.applyMigration(m, version+1); err != nil {
+			return fmt.Errorf("migrating to schema version %d (%s): %w", version+1, m.name, err)
+		}
+		version++
+	}
+	return nil
+}
+
+// applyMigration runs a single migration and stamps the new schema version
+// into the config, atomically: either both land or neither does.
+func (r *Repository) applyMigration(m *migration, version int32) error {
+	tx, err := r.db.Beginx()
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+
+	if _, err := tx.Exec(m.sql); err != nil {
+		return err
+	}
+
+	config := proto.Clone(&r.Config).(*pb.Config)
+	config.SchemaVersion = version
+	if err := writeConfig(tx, config); err != nil {
+		return err
+	}
+
+	if err := tx.Commit(); err != nil {
+		return err
+	}
+	r.Config.SchemaVersion = version
+	return nil
+}
+
+func writeConfig(db sqlx.Execer, config *pb.Config) error {
+	data, err := proto.Marshal(config)
+	if err != nil {
+		return err
+	}
+	_, err = db.Exec(sql_write_config, data)
+	return err
+}

--- a/repo/migrate_test.go
+++ b/repo/migrate_test.go
@@ -1,0 +1,200 @@
+package repo
+
+import (
+	"path"
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/golang/protobuf/ptypes/timestamp"
+	_ "github.com/mattn/go-sqlite3"
+	"google.golang.org/protobuf/proto"
+
+	"crossme.app/src/pb"
+)
+
+func tableColumns(t *testing.T, r *Repository, table string) []string {
+	t.Helper()
+	rows, err := r.db.Query("SELECT name FROM pragma_table_info(?)", table)
+	if err != nil {
+		t.Fatalf("pragma_table_info(%s): %v", table, err)
+	}
+	defer rows.Close()
+	var out []string
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		out = append(out, name)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("pragma_table_info(%s): %v", table, err)
+	}
+	return out
+}
+
+// A fresh database is built by running every migration in order, and ends up
+// at the current version with a usable schema.
+func TestMigrateFromScratch(t *testing.T) {
+	t.Parallel()
+	repo, err := Open(":memory:")
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer repo.Close()
+
+	if v := repo.Config.SchemaVersion; v != CurrentSchemaVersion {
+		t.Errorf("schema version %d, want %d", v, CurrentSchemaVersion)
+	}
+	for _, table := range []string{"config", "puzzles", "games", "puz_files"} {
+		if len(tableColumns(t, repo, table)) == 0 {
+			t.Errorf("table %q is missing", table)
+		}
+	}
+	if cols := tableColumns(t, repo, "games"); !slices.Contains(cols, "completed_at") {
+		t.Errorf("games table lacks completed_at: %v", cols)
+	}
+}
+
+// An old database is migrated forward on open, preserving the data it
+// already holds.
+func TestMigrateForward(t *testing.T) {
+	t.Parallel()
+	dbpath := path.Join(t.TempDir(), "crossme.db")
+
+	old, err := open(dbpath, 1)
+	if err != nil {
+		t.Fatalf("open at v1: %v", err)
+	}
+	if v := old.Config.SchemaVersion; v != 1 {
+		t.Fatalf("schema version %d, want 1", v)
+	}
+	if cols := tableColumns(t, old, "games"); slices.Contains(cols, "completed_at") {
+		t.Fatalf("v1 games table already has completed_at: %v", cols)
+	}
+	game, err := old.NewGame("some-puzzle")
+	if err != nil {
+		t.Fatalf("NewGame: %v", err)
+	}
+	if err := old.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	repo, err := Open(dbpath)
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	defer repo.Close()
+
+	if v := repo.Config.SchemaVersion; v != CurrentSchemaVersion {
+		t.Errorf("schema version %d, want %d", v, CurrentSchemaVersion)
+	}
+	if cols := tableColumns(t, repo, "games"); !slices.Contains(cols, "completed_at") {
+		t.Errorf("games table lacks completed_at after migration: %v", cols)
+	}
+
+	got, err := repo.GameById(game.Id)
+	if err != nil {
+		t.Fatalf("GameById: %v", err)
+	}
+	if !proto.Equal(got, game) {
+		t.Errorf("game did not survive migration: got %v want %v", got, game)
+	}
+
+	// The new column is writable, and NULL for rows that predate it.
+	var completed *string
+	if err := repo.db.Get(&completed, "SELECT completed_at FROM games WHERE id = ?", game.Id); err != nil {
+		t.Fatalf("select completed_at: %v", err)
+	}
+	if completed != nil {
+		t.Errorf("completed_at = %q, want NULL", *completed)
+	}
+	got.CompletedAt = &timestamp.Timestamp{Seconds: time.Now().Unix()}
+	if err := repo.UpdateGame(got); err != nil {
+		t.Fatalf("UpdateGame: %v", err)
+	}
+	if err := repo.db.Get(&completed, "SELECT completed_at FROM games WHERE id = ?", game.Id); err != nil {
+		t.Fatalf("select completed_at: %v", err)
+	}
+	if completed == nil {
+		t.Errorf("completed_at is still NULL after UpdateGame")
+	}
+}
+
+// Reopening an up-to-date database re-runs nothing.
+func TestMigrateIsIdempotent(t *testing.T) {
+	t.Parallel()
+	dbpath := path.Join(t.TempDir(), "crossme.db")
+
+	for i := 0; i < 3; i++ {
+		repo, err := Open(dbpath)
+		if err != nil {
+			t.Fatalf("open #%d: %v", i, err)
+		}
+		if v := repo.Config.SchemaVersion; v != CurrentSchemaVersion {
+			t.Errorf("open #%d: schema version %d, want %d", i, v, CurrentSchemaVersion)
+		}
+		if err := repo.Close(); err != nil {
+			t.Fatalf("close #%d: %v", i, err)
+		}
+	}
+}
+
+// A database written by a newer build is refused rather than silently
+// misinterpreted.
+func TestRefuseFutureSchema(t *testing.T) {
+	t.Parallel()
+	dbpath := path.Join(t.TempDir(), "crossme.db")
+
+	repo, err := Open(dbpath)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	if err := writeConfig(repo.db, &pb.Config{SchemaVersion: CurrentSchemaVersion + 1}); err != nil {
+		t.Fatalf("writeConfig: %v", err)
+	}
+	if err := repo.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	if _, err := Open(dbpath); err == nil {
+		t.Errorf("opening a future-versioned database succeeded")
+	}
+}
+
+// A failed migration leaves the database untouched, including its recorded
+// version.
+func TestMigrationIsAtomic(t *testing.T) {
+	t.Parallel()
+	repo, err := open(":memory:", 0)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer repo.Close()
+
+	bad := migration{name: "bogus", sql: `CREATE TABLE t (x text) strict; SELECT nonesuch();`}
+	if err := repo.applyMigration(&bad, 1); err == nil {
+		t.Fatalf("bogus migration succeeded")
+	}
+	if v := repo.Config.SchemaVersion; v != 0 {
+		t.Errorf("schema version %d after failed migration, want 0", v)
+	}
+	if cols := tableColumns(t, repo, "t"); len(cols) != 0 {
+		t.Errorf("failed migration left table t behind: %v", cols)
+	}
+}
+
+func TestMigrationNames(t *testing.T) {
+	t.Parallel()
+	seen := make(map[string]bool)
+	for i, m := range migrations {
+		if m.name == "" {
+			t.Errorf("migration %d has no name", i+1)
+		}
+		if seen[m.name] {
+			t.Errorf("migration %d: duplicate name %q", i+1, m.name)
+		}
+		seen[m.name] = true
+	}
+}

--- a/repo/mutate.go
+++ b/repo/mutate.go
@@ -10,12 +10,7 @@ import (
 )
 
 func (r *Repository) FlushConfig() error {
-	data, err := proto.Marshal(&r.Config)
-	if err != nil {
-		return err
-	}
-	_, err = r.db.Exec("REPLACE INTO config (id, proto) VALUES(0, ?)", data)
-	return err
+	return writeConfig(r.db, &r.Config)
 }
 
 func (r *Repository) InsertPuzzle(puz *pb.Puzzle, blob []byte) (string, error) {

--- a/repo/repo.go
+++ b/repo/repo.go
@@ -2,12 +2,9 @@ package repo
 
 import (
 	"context"
-	"database/sql"
 	"fmt"
 	"net/url"
 	"strings"
-
-	"google.golang.org/protobuf/proto"
 
 	"crossme.app/src/pb"
 	"github.com/jmoiron/sqlx"
@@ -20,6 +17,12 @@ type Repository struct {
 }
 
 func Open(dsn string) (*Repository, error) {
+	return open(dsn, CurrentSchemaVersion)
+}
+
+// open opens a database and migrates it to `target`. Callers other than
+// tests always want CurrentSchemaVersion.
+func open(dsn string, target int32) (*Repository, error) {
 	bits := strings.SplitN(dsn, "?", 2)
 	var q url.Values
 	if len(bits) > 1 {
@@ -43,31 +46,18 @@ func Open(dsn string) (*Repository, error) {
 	}
 
 	repo := &Repository{db: sql}
-	if err := repo.init(); err != nil {
+	if err := repo.init(target); err != nil {
 		repo.Close()
 		return nil, err
 	}
 	return repo, nil
 }
 
-func (r *Repository) init() error {
-	if _, err := r.db.Exec(sql_init); err != nil {
-		return fmt.Errorf("error loading schema: %v", err)
+func (r *Repository) init(target int32) error {
+	if err := r.loadConfig(); err != nil {
+		return err
 	}
-	var config_bytes []byte
-	if err := r.db.Get(&config_bytes, "SELECT proto FROM config LIMIT 1"); err != nil {
-		if err != sql.ErrNoRows {
-			return fmt.Errorf("error loading config: %v", err)
-		}
-	}
-	if config_bytes != nil {
-		err := proto.Unmarshal(config_bytes, &r.Config)
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
+	return r.migrate(target)
 }
 
 // Ping checks that the database is still usable. It's meant for health

--- a/repo/repo_test.go
+++ b/repo/repo_test.go
@@ -22,20 +22,14 @@ func TestOpenEmpty(t *testing.T) {
 	if repo.db == nil {
 		t.Fatalf("open: nil db")
 	}
-	if v := repo.Config.SchemaVersion; v != 0 {
-		t.Fatalf("schema version %d", v)
+	if v := repo.Config.SchemaVersion; v != CurrentSchemaVersion {
+		t.Fatalf("schema version %d, want %d", v, CurrentSchemaVersion)
 	}
 }
 
 func TestRoundTripConfig(t *testing.T) {
 	t.Parallel()
-	td, err := os.MkdirTemp("", "crossme.test.*")
-	if err != nil {
-		t.Fatalf("mktemp: %v", err)
-	}
-	defer os.RemoveAll(td)
-
-	dbpath := path.Join(td, "crossme.db")
+	dbpath := path.Join(t.TempDir(), "crossme.db")
 
 	repo, err := Open(dbpath)
 	if err != nil {
@@ -43,9 +37,6 @@ func TestRoundTripConfig(t *testing.T) {
 	}
 	defer repo.Close()
 
-	var version int32 = 32
-
-	repo.Config.SchemaVersion = version
 	if err := repo.FlushConfig(); err != nil {
 		t.Fatal("FlushConfig", err)
 	}
@@ -55,7 +46,7 @@ func TestRoundTripConfig(t *testing.T) {
 		t.Fatal("reopen", err)
 	}
 	defer r2.Close()
-	if v := r2.Config.SchemaVersion; v != version {
+	if v := r2.Config.SchemaVersion; v != CurrentSchemaVersion {
 		t.Fatalf("wrong config version on reopen: %d", v)
 	}
 }

--- a/repo/sql.go
+++ b/repo/sql.go
@@ -2,36 +2,7 @@ package repo
 
 import "database/sql"
 
-const sql_init = `
-CREATE TABLE IF NOT EXISTS config (
-  id int primary key not null,
-  proto blob not null
-) strict;
-
-CREATE TABLE IF NOT EXISTS puzzles (
-  proto blob not null,
-  title text not null,
-  meta__sha256 text null unique,
-  meta__id text unique not null primary key,
-  meta__date text not null,
-  meta__created text not null
-) strict;
-
-CREATE INDEX IF NOT EXISTS puzzles__date ON puzzles (meta__date);
-
-CREATE TABLE IF NOT EXISTS games (
-  proto blob not null,
-  id text not null unique primary key,
-  puzzle_id text not null,
-  created text not null,
-  completed_at text null
-) strict;
-
-CREATE TABLE IF NOT EXISTS puz_files (
-  sha256 text unique primary key,
-  file blob
-) strict;
-`
+// The schema itself lives in migrate.go, as a sequence of migrations.
 
 const sql_insert_puz_file = `
 REPLACE INTO puz_files(sha256, file) VALUES (:sha256, :blob)


### PR DESCRIPTION
## Summary
Refactor the database initialization to use an explicit migration system instead of creating all tables at once. This enables incremental schema evolution and provides a foundation for future schema changes.

## Key Changes
- **New migration system** (`migrate.go`): Introduced a `migration` struct and `migrations` slice that define schema changes as an append-only sequence. Each migration moves the database from one schema version to the next.
- **Schema versioning**: Added `CurrentSchemaVersion` constant that tracks the expected schema version. The config table now stores the actual schema version, allowing detection of version mismatches.
- **Atomic migrations**: Implemented `applyMigration()` to run each migration in its own transaction, ensuring atomicity—if a migration fails, the database version remains unchanged and no partial schema changes are left behind.
- **Forward compatibility**: Added validation to refuse opening databases with a schema version newer than the current build knows about, preventing silent data misinterpretation.
- **Comprehensive test coverage** (`migrate_test.go`): Added five test cases covering:
  - Fresh database initialization through all migrations
  - Forward migration of old databases while preserving data
  - Idempotency of repeated opens
  - Rejection of future-versioned databases
  - Atomicity of failed migrations
  - Uniqueness of migration names

## Implementation Details
- The config table is created outside the migration sequence on every open, as it's needed to determine which migrations to run.
- The initial schema (puzzles, games, puz_files tables) is now migration #1, with the `completed_at` column addition as migration #2.
- The `open()` function accepts a target schema version parameter, allowing tests to open databases at specific versions for migration testing.
- Migration SQL is stored as plain strings in the `migration` struct, making it easy to review and audit schema changes.

## Notes
Since crossme is not yet deployed, this change is backwards-incompatible with any existing databases, but establishes the infrastructure for safe schema evolution going forward.

https://claude.ai/code/session_01PbectJWM5hhfpv3iUQSnto