### PR TITLE
Add prev/next clue arrows and tap-to-swap to the mobile clue bar

### DIFF
--- a/client/src/components/current_clue.tsx
+++ b/client/src/components/current_clue.tsx
@@ -1,17 +1,57 @@
+import React from "react";
+
 import { Clue, Direction } from "../types";
 
 export interface CurrentClueProps {
   clue: Clue;
   direction: Direction;
+  onPrev: () => void;
+  onNext: () => void;
+  onToggle: () => void;
 }
 
-export const CurrentClue = ({ clue, direction }: CurrentClueProps) => (
+// Keep the grid's hidden input focused: a control that took focus on
+// tap would dismiss the mobile keyboard.
+const keepFocus = (e: React.PointerEvent) => e.preventDefault();
+
+export const CurrentClue = ({
+  clue,
+  direction,
+  onPrev,
+  onNext,
+  onToggle,
+}: CurrentClueProps) => (
   <div id="theclue">
-    <span className="badge bg-secondary">
-      <span className="number">{clue.number}</span>
-      <span className="direction"> {direction}</span>
+    <button
+      type="button"
+      className="clue-nav prev"
+      aria-label="Previous clue"
+      onPointerDown={keepFocus}
+      onClick={onPrev}
+    >
+      &lsaquo;
+    </button>
+    <span
+      className="body"
+      title="Switch direction"
+      onPointerDown={keepFocus}
+      onClick={onToggle}
+    >
+      <span className="badge bg-secondary">
+        <span className="number">{clue.number}</span>
+        <span className="direction"> {direction}</span>
+      </span>
+      <span className="text">{clue.text}</span>
     </span>
-    <span className="text">{clue.text}</span>
+    <button
+      type="button"
+      className="clue-nav next"
+      aria-label="Next clue"
+      onPointerDown={keepFocus}
+      onClick={onNext}
+    >
+      &rsaquo;
+    </button>
     <div className="clear" />
   </div>
 );

--- a/client/src/components/puzzle.tsx
+++ b/client/src/components/puzzle.tsx
@@ -56,6 +56,9 @@ export class PuzzleComponent extends React.Component<PuzzleProps, PuzzleState> {
     this.setPencil = this.setPencil.bind(this);
     this.doReveal = this.doReveal.bind(this);
     this.doCheck = this.doCheck.bind(this);
+    this.prevClue = this.prevClue.bind(this);
+    this.nextClue = this.nextClue.bind(this);
+    this.toggleDirection = this.toggleDirection.bind(this);
   }
 
   updateGame(op: (g: Crossword.Game) => Crossword.GameUpdate) {
@@ -205,6 +208,18 @@ export class PuzzleComponent extends React.Component<PuzzleProps, PuzzleState> {
     this.updateGame((game) => Crossword.selectClue(game, evt));
   }
 
+  prevClue() {
+    this.updateGame((game) => Crossword.adjacentClue(game, true));
+  }
+
+  nextClue() {
+    this.updateGame((game) => Crossword.adjacentClue(game));
+  }
+
+  toggleDirection() {
+    this.updateGame(Crossword.swapDirection);
+  }
+
   doReveal(target: Crossword.Target) {
     this.updateGame((game) => Crossword.revealAnswers(game, target));
   }
@@ -328,6 +343,9 @@ export class PuzzleComponent extends React.Component<PuzzleProps, PuzzleState> {
           <CurrentClue
             clue={this.selectedClue()}
             direction={this.direction()}
+            onPrev={this.prevClue}
+            onNext={this.nextClue}
+            onToggle={this.toggleDirection}
           />
         )}
         <PuzzleGrid

--- a/client/src/components/style/puzzle.css
+++ b/client/src/components/style/puzzle.css
@@ -43,9 +43,21 @@
   margin: 5px 0px;
 }
 
-#theclue > span {
+#theclue .body > span {
   padding: 5px;
   font-weight: bold;
+}
+
+/* Tapping the clue swaps direction. */
+#theclue .body {
+  cursor: pointer;
+  user-select: none;
+}
+
+/* Previous/next-clue arrows; only shown on mobile, where the clue
+   list is hidden and there's no other way to browse clues. */
+#theclue .clue-nav {
+  display: none;
 }
 
 #theclue .label {
@@ -316,9 +328,34 @@
     right: 0px;
     background-color: white;
     border-top: 2px solid black;
-    padding: 10px;
+    padding: 10px 0px;
     margin: 0;
     z-index: 5;
+    display: flex;
+    align-items: center;
+  }
+
+  #theclue .body {
+    flex: 1;
+    min-width: 0;
+  }
+
+  #theclue .clue-nav {
+    display: block;
+    flex: none;
+    align-self: stretch;
+    width: 2em;
+    padding: 0;
+    border: none;
+    background: none;
+    color: inherit;
+    font-size: 160%;
+    line-height: 1;
+    touch-action: manipulation;
+  }
+
+  #theclue .clue-nav:active {
+    background-color: #ccf;
   }
 
   /* While the clue is pinned, scroll inside .App instead of the

--- a/client/src/crossword.test.ts
+++ b/client/src/crossword.test.ts
@@ -437,6 +437,78 @@ describe("crossword operations", () => {
 # . . . #
 `,
     ],
+    [
+      "Next clue moves to the start of the following clue",
+      `
+# . .>. #
+. . . . .
+. . # . .
+. . . . .
+# . . . #
+`,
+      (g) => Crossword.adjacentClue(g),
+      `
+# . . . #
+.>. . . .
+. . # . .
+. . . . .
+# . . . #
+`,
+    ],
+    [
+      "Next clue continues from the last across into the first down",
+      `
+# . . . #
+. . . . .
+. . # . .
+. . . . .
+# . .>. #
+`,
+      (g) => Crossword.adjacentClue(g),
+      `
+# .v. . #
+. . . . .
+. . # . .
+. . . . .
+# . . . #
+`,
+    ],
+    [
+      "Previous clue moves to the start of the preceding clue",
+      `
+# . . . #
+. .>. . .
+. . # . .
+. . . . .
+# . . . #
+`,
+      (g) => Crossword.adjacentClue(g, true),
+      `
+# .>. . #
+. . . . .
+. . # . .
+. . . . .
+# . . . #
+`,
+    ],
+    [
+      "Previous clue wraps from the first across to the last down",
+      `
+# .>. . #
+. . . . .
+. . # . .
+. . . . .
+# . . . #
+`,
+      (g) => Crossword.adjacentClue(g, true),
+      `
+# . . . #
+. . . . .
+. . # . .
+. . .v. .
+# . . . #
+`,
+    ],
   ];
   testCases.forEach(([name, before, op, after], i) => {
     it(`${name} [index: ${i}]`, () => {

--- a/client/src/crossword.ts
+++ b/client/src/crossword.ts
@@ -582,6 +582,17 @@ export function nextBlank(g: Game, reverse?: boolean): GameUpdate {
   );
 }
 
+// Moves the cursor to the start of the next (or, with `reverse`, the
+// previous) clue in puzzle order: through the rest of the current
+// direction's clues, then the other direction's, wrapping around.
+export function adjacentClue(g: Game, reverse?: boolean): GameUpdate {
+  return nextClue(
+    g,
+    (direction, clue) => ({ ...g.by_clue[clue.number], direction }),
+    reverse
+  );
+}
+
 export function keypress(g: Game, text: string): GameUpdate {
   const oldFill = fillAt(g, g.cursor);
   const update = fillSquare(g, text);


### PR DESCRIPTION
On mobile the clue list is hidden, so the pinned clue bar was the only
view of the clues but offered no way to browse them. Add previous/next
arrows at its left and right edges, backed by a new Crossword.adjacentClue
that walks clues in puzzle order (across, then down, wrapping). Tapping
the clue itself now swaps direction, matching a tap on the selected cell.

The controls swallow pointerdown so the grid's hidden input keeps focus
and the on-screen keyboard stays up. The arrows are hidden outside the
mobile breakpoint, where the clue box already covers navigation.

Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0158Axq3hwueiUYsEh5giJwN