### PR TITLE
[wip] Set up preview deployments for PRs

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,54 @@
+name: Preview
+
+# Deploys every pull request as its own Fly.io app, built from
+# Dockerfile.preview (see fly.toml), and destroys the app when the PR closes.
+# The preview runs the whole app in one container on an empty database.
+#
+# Needs the FLY_API_TOKEN repository secret: an org-scoped Fly token, since the
+# action creates and destroys apps (`fly tokens create org`).
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, closed]
+
+env:
+  FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+  FLY_ORG: personal
+  FLY_REGION: sjc
+
+permissions:
+  contents: read
+  deployments: write
+
+jobs:
+  preview:
+    runs-on: ubuntu-latest
+
+    # Forks don't get repository secrets, so a fork PR can't deploy anyway;
+    # skip rather than fail.
+    if: github.event.pull_request.head.repo.full_name == github.repository
+
+    # One deploy at a time per PR. Deliberately not cancel-in-progress: a
+    # destroy on close must not race a half-finished deploy.
+    concurrency:
+      group: preview-pr-${{ github.event.number }}
+
+    # A GitHub deployment environment per PR, so the preview URL shows up in
+    # the pull request's sidebar.
+    environment:
+      name: preview-pr-${{ github.event.number }}
+      url: ${{ steps.deploy.outputs.url }}
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Deploy preview
+        id: deploy
+        uses: superfly/fly-pr-review-apps@1.5.0
+        with:
+          name: crossme-pr-${{ github.event.number }}
+          # The app has no way to learn its own public URL, and needs it for
+          # OAuth redirects. Google login itself stays off in previews until
+          # each preview host can be authorized somehow; this just keeps the
+          # base URL correct for when it is.
+          secrets: CROSSME_BASE_URL=https://crossme-pr-${{ github.event.number }}.fly.dev

--- a/Dockerfile.preview
+++ b/Dockerfile.preview
@@ -1,0 +1,77 @@
+# syntax=docker/dockerfile:1
+
+# A single image running the whole app — the Go server, serving the built SPA
+# itself — for transient per-PR preview instances.
+#
+# Production does not use this. There the client and the server ship as two
+# images: client/Dockerfile puts the bundle behind nginx (client/nginx.conf),
+# which proxies /api/ to the Go server from the root Dockerfile. This image
+# exists so a preview is one container with nothing to wire together; the
+# server reproduces nginx's SPA fallback and response headers behind
+# -static-dir.
+
+# Keep GO_VERSION in sync with go.mod, and NODE_VERSION with client/Dockerfile.
+# The builder and the runtime pin the same Alpine release so the cgo build and
+# the runtime agree on musl.
+ARG GO_VERSION=1.25
+ARG ALPINE_VERSION=3.22
+ARG NODE_VERSION=24
+
+FROM node:${NODE_VERSION}-alpine AS client
+
+WORKDIR /src
+
+# Install dependencies in their own layer, keyed only on the lockfile.
+COPY client/package.json client/package-lock.json ./
+RUN --mount=type=cache,target=/root/.npm \
+    npm ci
+
+COPY client/ ./
+RUN npm run build
+
+FROM golang:${GO_VERSION}-alpine${ALPINE_VERSION} AS build
+
+# github.com/mattn/go-sqlite3 is a cgo package, so we need a C toolchain.
+RUN apk add --no-cache build-base
+
+WORKDIR /src
+
+# Download modules in their own layer so editing source doesn't refetch them.
+COPY go.mod go.sum ./
+RUN --mount=type=cache,target=/go/pkg/mod \
+    go mod download
+
+COPY . .
+
+# Link statically so the resulting binary doesn't care what's in the runtime
+# image. sqlite_omit_load_extension drops sqlite's extension loader, which we
+# never use and don't want to expose. Only the server is built here; a preview
+# has no use for the crossme-build-db tool.
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    CGO_ENABLED=1 go build \
+      -trimpath \
+      -tags sqlite_omit_load_extension \
+      -ldflags '-s -w -extldflags "-static"' \
+      -o /out/ ./cmd/crossme
+
+FROM alpine:${ALPINE_VERSION}
+
+RUN apk add --no-cache ca-certificates tzdata \
+ && adduser -S -D -H -u 10001 crossme \
+ && mkdir -p /data \
+ && chown crossme /data
+
+COPY --from=build /out/crossme /usr/local/bin/
+COPY --from=client /src/dist /crossme/dist
+
+# No VOLUME for /data on purpose: a preview instance starts from an empty
+# database and its state is meant to die with the container.
+USER crossme
+EXPOSE 4000
+
+HEALTHCHECK --interval=30s --timeout=3s --start-period=5s \
+  CMD wget -q -O /dev/null http://127.0.0.1:4000/healthz
+
+ENTRYPOINT ["crossme"]
+CMD ["-bind", "0.0.0.0:4000", "-db", "/data/crossme.db", "-static-dir", "/crossme/dist"]

--- a/Dockerfile.preview.dockerignore
+++ b/Dockerfile.preview.dockerignore
@@ -1,0 +1,15 @@
+# Applies only to Dockerfile.preview: BuildKit prefers
+# <Dockerfile-name>.dockerignore over .dockerignore when it exists, so this
+# file requires BuildKit (the default builder since Docker 23).
+#
+# The root .dockerignore excludes client/, which the two-image production build
+# doesn't need but this one does; hence the separate list.
+.git/
+.github/
+bin/
+data/
+docs/
+*.md
+client/node_modules/
+client/dist/
+client/coverage/

--- a/README.md
+++ b/README.md
@@ -33,3 +33,23 @@ registered as an authorized redirect URI — e.g.
 `http://localhost:3000/api/auth/google/callback` for development.
 
 [3]: https://console.cloud.google.com/apis/credentials
+
+Preview image
+-------------
+
+`Dockerfile.preview` builds the client and the server into a single
+image, for throwaway per-PR preview instances. (Production keeps the two
+apart: `Dockerfile` for the Go server, and `client/Dockerfile` +
+`client/nginx.conf` for the bundle behind nginx.) The server serves the
+built client itself here, via `-static-dir` / `CROSSME_STATIC_DIR`.
+
+    docker build -f Dockerfile.preview -t crossme-preview .
+    docker run -p 4000:4000 crossme-preview
+
+The app is then at `http://localhost:4000`. Each container starts on an
+empty database, and that database dies with the container. Google login
+is off by default and enabled exactly as in production, with
+`CROSSME_GOOGLE_CLIENT_ID`, `CROSSME_GOOGLE_CLIENT_SECRET` and
+`CROSSME_BASE_URL` (the last being the URL the browser reaches the
+preview at, whose `/api/auth/google/callback` must be a registered
+redirect URI).

--- a/README.md
+++ b/README.md
@@ -53,3 +53,9 @@ is off by default and enabled exactly as in production, with
 `CROSSME_BASE_URL` (the last being the URL the browser reaches the
 preview at, whose `/api/auth/google/callback` must be a registered
 redirect URI).
+
+Every pull request is deployed as a preview from this image by
+`.github/workflows/preview.yml`, as a Fly.io app named
+`crossme-pr-<number>` (config in `fly.toml`), destroyed when the PR
+closes. The workflow needs an org-scoped Fly API token in the
+`FLY_API_TOKEN` repository secret.

--- a/cmd/crossme/main.go
+++ b/cmd/crossme/main.go
@@ -33,6 +33,13 @@ func main() {
 		baseURL = flag.String("base-url",
 			envDefault("CROSSME_BASE_URL", "http://localhost:3000"),
 			"external base URL the browser reaches us at, for OAuth redirects")
+
+		// In production nginx serves the built client and proxies /api/ here.
+		// Preview instances run everything in one container instead, so we can
+		// optionally serve the bundle ourselves; empty means we don't.
+		staticDir = flag.String("static-dir",
+			os.Getenv("CROSSME_STATIC_DIR"),
+			"directory of built client assets to serve at /; empty disables static serving")
 	)
 	flag.Parse()
 
@@ -84,6 +91,19 @@ func main() {
 	// calling.
 	mux.Handle("/api"+path, http.StripPrefix("/api", authHandler.Middleware(handler)))
 
+	if *staticDir != "" {
+		spa, err := newSPAHandler(*staticDir)
+		if err != nil {
+			log.Fatal("-static-dir: ", err)
+		}
+		// An unmatched path under /api/ is an API error, not a client-side
+		// route; without this it would fall through to the catch-all below and
+		// answer with the app shell. The API and /healthz patterns registered
+		// above are more specific, so they still win.
+		mux.Handle("/api/", http.NotFoundHandler())
+		mux.Handle("/", spa)
+	}
+
 	// h2c lets HTTP/2 clients (gRPC, and Connect over HTTP/2) talk to us
 	// without TLS; browsers use the Connect protocol over HTTP/1.1.
 	httpServer := &http.Server{
@@ -91,7 +111,11 @@ func main() {
 		Handler: h2c.NewHandler(mux, &http2.Server{}),
 	}
 
-	log.Printf("listening on %s", *bind)
+	if *staticDir != "" {
+		log.Printf("listening on %s (serving %s at /)", *bind, *staticDir)
+	} else {
+		log.Printf("listening on %s", *bind)
+	}
 	if err := httpServer.ListenAndServe(); err != nil {
 		log.Fatal("ListenAndServe: ", err)
 	}

--- a/cmd/crossme/static.go
+++ b/cmd/crossme/static.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"fmt"
+	"io/fs"
+	"net/http"
+	"os"
+	"path"
+	"strings"
+)
+
+// These mirror the headers client/nginx.conf sets in production, where nginx
+// serves the built client and proxies /api/ to us. The preview image collapses
+// both jobs into this process, so the responses have to look the same.
+const (
+	// We serve our own JS and talk only to our own API; lock the page down to
+	// that. 'unsafe-inline' is needed for react-select/bootstrap's injected
+	// styles. googleusercontent.com hosts the avatars of users signed in with
+	// Google.
+	staticCSP = "default-src 'self'; style-src 'self' 'unsafe-inline'; " +
+		"img-src 'self' data: https://*.googleusercontent.com; connect-src 'self'; " +
+		"frame-ancestors 'none'; base-uri 'self'"
+
+	// Vite emits content-hashed filenames under /assets/, so those are
+	// immutable. Everything else (chiefly index.html) must be revalidated so a
+	// deploy doesn't strand clients on a stale app shell.
+	immutableCacheControl = "max-age=31536000,immutable"
+	defaultCacheControl   = "no-cache"
+)
+
+// spaHandler serves a built client bundle out of a directory, with the
+// single-page-app fallback nginx spells `try_files $uri $uri/ /index.html`:
+// anything that isn't a file on disk gets the app shell, and the client router
+// takes it from there. It never lists directories.
+type spaHandler struct {
+	fsys fs.FS
+}
+
+// newSPAHandler fails if dir doesn't look like a built client, so a
+// misconfigured -static-dir is a startup error rather than a site that 404s
+// every page.
+func newSPAHandler(dir string) (*spaHandler, error) {
+	fsys := os.DirFS(dir)
+	if _, err := fs.Stat(fsys, "index.html"); err != nil {
+		return nil, fmt.Errorf("%s: %w", path.Join(dir, "index.html"), err)
+	}
+	return &spaHandler{fsys: fsys}, nil
+}
+
+func (h *spaHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	hdr := w.Header()
+	hdr.Set("Content-Security-Policy", staticCSP)
+	hdr.Set("X-Content-Type-Options", "nosniff")
+	hdr.Set("Referrer-Policy", "same-origin")
+
+	if req.Method != http.MethodGet && req.Method != http.MethodHead {
+		hdr.Set("Cache-Control", defaultCacheControl)
+		hdr.Set("Allow", "GET, HEAD")
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	// path.Clean resolves any ".." the mux didn't already redirect away, and
+	// fs.ValidPath rejects anything still malformed, so we only ever open names
+	// rooted inside the directory.
+	name := strings.TrimPrefix(path.Clean("/"+req.URL.Path), "/")
+	if name != "" && fs.ValidPath(name) {
+		// Only regular files are served: a directory falls through to the app
+		// shell rather than producing a listing.
+		if st, err := fs.Stat(h.fsys, name); err == nil && st.Mode().IsRegular() {
+			hdr.Set("Cache-Control", cacheControlFor(req.URL.Path))
+			http.ServeFileFS(w, req, h.fsys, name)
+			return
+		}
+	}
+
+	// The fallback is always the app shell, which must be revalidated even
+	// under /assets/ — a hashed name that doesn't exist isn't immutable.
+	hdr.Set("Cache-Control", defaultCacheControl)
+	http.ServeFileFS(w, req, h.fsys, "index.html")
+}
+
+func cacheControlFor(urlPath string) string {
+	if strings.HasPrefix(urlPath, "/assets/") {
+		return immutableCacheControl
+	}
+	return defaultCacheControl
+}

--- a/cmd/crossme/static_test.go
+++ b/cmd/crossme/static_test.go
@@ -1,0 +1,192 @@
+package main
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const testIndex = "<!doctype html><title>crossme</title>"
+
+// buildDist writes a stand-in for a built client bundle.
+func buildDist(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "index.html"), []byte(testIndex), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(filepath.Join(dir, "assets"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "assets", "app-abc123.js"), []byte("console.log(1)\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+func newTestSPA(t *testing.T) *spaHandler {
+	t.Helper()
+	h, err := newSPAHandler(buildDist(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return h
+}
+
+func get(t *testing.T, h http.Handler, target string) *http.Response {
+	t.Helper()
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, httptest.NewRequest("GET", target, nil))
+	return w.Result()
+}
+
+func body(t *testing.T, resp *http.Response) string {
+	t.Helper()
+	b, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(b)
+}
+
+func TestSPAMissingIndex(t *testing.T) {
+	if _, err := newSPAHandler(t.TempDir()); err == nil {
+		t.Fatal("expected an error for a directory with no index.html")
+	}
+}
+
+func TestSPAServesIndex(t *testing.T) {
+	resp := get(t, newTestSPA(t), "/")
+	if resp.StatusCode != 200 {
+		t.Fatalf("GET /: status %d", resp.StatusCode)
+	}
+	if got := body(t, resp); got != testIndex {
+		t.Errorf("GET /: body %q", got)
+	}
+	if ct := resp.Header.Get("Content-Type"); !strings.HasPrefix(ct, "text/html") {
+		t.Errorf("GET /: Content-Type %q", ct)
+	}
+	if cc := resp.Header.Get("Cache-Control"); cc != defaultCacheControl {
+		t.Errorf("GET /: Cache-Control %q", cc)
+	}
+}
+
+func TestSPASecurityHeaders(t *testing.T) {
+	for _, path := range []string{"/", "/assets/app-abc123.js", "/games/abc"} {
+		resp := get(t, newTestSPA(t), path)
+		for header, want := range map[string]string{
+			"Content-Security-Policy": staticCSP,
+			"X-Content-Type-Options":  "nosniff",
+			"Referrer-Policy":         "same-origin",
+		} {
+			if got := resp.Header.Get(header); got != want {
+				t.Errorf("GET %s: %s = %q, want %q", path, header, got, want)
+			}
+		}
+	}
+}
+
+func TestSPAServesAssetImmutably(t *testing.T) {
+	resp := get(t, newTestSPA(t), "/assets/app-abc123.js")
+	if resp.StatusCode != 200 {
+		t.Fatalf("status %d", resp.StatusCode)
+	}
+	if got := body(t, resp); got != "console.log(1)\n" {
+		t.Errorf("body %q", got)
+	}
+	if cc := resp.Header.Get("Cache-Control"); cc != immutableCacheControl {
+		t.Errorf("Cache-Control %q, want %q", cc, immutableCacheControl)
+	}
+}
+
+// An unknown path is a client-side route: it gets the app shell, and the shell
+// must stay revalidated so a deploy doesn't strand clients on a stale one.
+func TestSPAFallsBackToIndex(t *testing.T) {
+	resp := get(t, newTestSPA(t), "/games/abc")
+	if resp.StatusCode != 200 {
+		t.Fatalf("status %d", resp.StatusCode)
+	}
+	if got := body(t, resp); got != testIndex {
+		t.Errorf("body %q, want the app shell", got)
+	}
+	if cc := resp.Header.Get("Cache-Control"); cc != defaultCacheControl {
+		t.Errorf("Cache-Control %q, want %q", cc, defaultCacheControl)
+	}
+}
+
+// A hashed asset that doesn't exist isn't immutable, whatever its path says.
+func TestSPAMissingAssetIsNotImmutable(t *testing.T) {
+	resp := get(t, newTestSPA(t), "/assets/gone-000000.js")
+	if got := body(t, resp); got != testIndex {
+		t.Errorf("body %q, want the app shell", got)
+	}
+	if cc := resp.Header.Get("Cache-Control"); cc != defaultCacheControl {
+		t.Errorf("Cache-Control %q, want %q", cc, defaultCacheControl)
+	}
+}
+
+// Directories get the app shell, never a listing.
+func TestSPANoDirectoryListing(t *testing.T) {
+	for _, path := range []string{"/assets", "/assets/"} {
+		resp := get(t, newTestSPA(t), path)
+		got := body(t, resp)
+		if got != testIndex {
+			t.Errorf("GET %s: body %q, want the app shell", path, got)
+		}
+		if strings.Contains(got, "app-abc123.js") {
+			t.Errorf("GET %s: response lists directory contents", path)
+		}
+	}
+}
+
+func TestSPARejectsWrites(t *testing.T) {
+	w := httptest.NewRecorder()
+	newTestSPA(t).ServeHTTP(w, httptest.NewRequest("POST", "/games/abc", nil))
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Errorf("POST: status %d, want 405", w.Code)
+	}
+}
+
+// The SPA catch-all must not swallow the API or the health check when it's
+// mounted alongside them, which is exactly how main wires it up.
+func TestSPADoesNotShadowAPI(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /healthz", func(w http.ResponseWriter, req *http.Request) {
+		io.WriteString(w, "ok\n")
+	})
+	mux.HandleFunc("GET /api/auth/{provider}/login", func(w http.ResponseWriter, req *http.Request) {
+		io.WriteString(w, "login:"+req.PathValue("provider"))
+	})
+	mux.HandleFunc("GET /api/auth/{provider}/callback", func(w http.ResponseWriter, req *http.Request) {
+		io.WriteString(w, "callback")
+	})
+	mux.HandleFunc("/api/crossme.CrossMe/", func(w http.ResponseWriter, req *http.Request) {
+		io.WriteString(w, "rpc:"+strings.TrimPrefix(req.URL.Path, "/api/crossme.CrossMe/"))
+	})
+	mux.Handle("/api/", http.NotFoundHandler())
+	mux.Handle("/", newTestSPA(t))
+
+	for target, want := range map[string]string{
+		"/healthz":                     "ok\n",
+		"/api/auth/google/login":       "login:google",
+		"/api/auth/google/callback":    "callback",
+		"/api/crossme.CrossMe/GetSelf": "rpc:GetSelf",
+	} {
+		if got := body(t, get(t, mux, target)); got != want {
+			t.Errorf("GET %s: body %q, want %q", target, got, want)
+		}
+	}
+
+	// Anything else under /api/ is a 404 from the API, not the app shell.
+	resp := get(t, mux, "/api/nope")
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("GET /api/nope: status %d, want 404", resp.StatusCode)
+	}
+	if got := body(t, resp); strings.Contains(got, "<!doctype html>") {
+		t.Errorf("GET /api/nope: served the app shell: %q", got)
+	}
+}

--- a/fly.toml
+++ b/fly.toml
@@ -1,0 +1,27 @@
+# Fly.io config for transient per-PR preview instances. Production does not
+# run on Fly; this file exists for .github/workflows/preview.yml, which uses
+# superfly/fly-pr-review-apps to create one app per pull request from it and
+# destroy the app when the PR closes. The action supplies the app name and
+# region itself, so neither is set here.
+
+[build]
+  dockerfile = "Dockerfile.preview"
+  # The root .dockerignore excludes client/, which this image needs.
+  ignorefile = "Dockerfile.preview.dockerignore"
+
+[http_service]
+  internal_port = 4000
+  force_https = true
+  # Previews sit idle almost all the time. Stop the machine when nothing is
+  # talking to it and wake it on the next request; a cold start is a
+  # second or two, which is fine for a preview.
+  auto_stop_machines = "stop"
+  auto_start_machines = true
+  min_machines_running = 0
+
+  [[http_service.checks]]
+    grace_period = "5s"
+    interval = "30s"
+    timeout = "3s"
+    method = "GET"
+    path = "/healthz"


### PR DESCRIPTION
Production serves the SPA from nginx (client/nginx.conf) and proxies
/api/ to us. That's two images to stand up, which is more machinery than
a throwaway per-PR preview wants. Add -static-dir (CROSSME_STATIC_DIR):
when it's set, we serve the bundle ourselves at /, reproducing nginx's
`try_files $uri $uri/ /index.html` fallback and its response headers --
the same CSP, nosniff, Referrer-Policy, and immutable caching for the
content-hashed files under /assets/ with everything else revalidated.

Unset, which stays the default, nothing changes: no static handler is
registered at all.

Directories fall back to the app shell rather than producing a listing,
and only GET and HEAD are answered. The catch-all is registered last and
is the least specific pattern on the mux, so the API, the auth redirect
endpoints, and /healthz keep precedence; unmatched paths under /api/ get
an API 404 instead of falling through to the shell. A -static-dir whose
index.html is missing is a startup error, not a site that 404s
every page.

Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016ZMpgBXk9Z4dRchLBoPb29