### PR TITLE
Show player's game status on puzzle list

### DIFF
--- a/client/src/components/puzzles.test.tsx
+++ b/client/src/components/puzzles.test.tsx
@@ -1,14 +1,17 @@
 import { fireEvent, render, screen, within } from "@testing-library/react";
 import { MemoryRouter, Route, Routes } from "react-router";
 import { create } from "@bufbuild/protobuf";
+import { timestampFromDate } from "@bufbuild/protobuf/wkt";
 
 import {
   GetPuzzleIndexResponseSchema,
+  GetSelfResponseSchema,
   NewGameResponseSchema,
 } from "../pb/crossme_pb";
-import { PuzzleIndexSchema } from "../pb/puzzle_pb";
+import { PuzzleIndexSchema, PuzzleIndex_GameSchema } from "../pb/puzzle_pb";
 import { ClientContext, type CrossMeClient } from "../rpc";
 import { groupByMonth, matchesQuery } from "../puzzle_index";
+import { UserProvider } from "../user_provider";
 import { Puzzles } from "./puzzles";
 
 const puzzle = (id: string, title: string, author: string, date: string) =>
@@ -128,4 +131,68 @@ it("explains an empty server", async () => {
       .mockResolvedValue(create(GetPuzzleIndexResponseSchema, {})),
   });
   expect(await screen.findByText(/no puzzles yet/)).toBeVisible();
+});
+
+describe("signed in", () => {
+  const signedInSelf = () =>
+    vi.fn().mockResolvedValue(
+      create(GetSelfResponseSchema, {
+        user: { id: "user-1", displayName: "Ada" },
+      })
+    );
+
+  function renderSignedIn(client: Partial<CrossMeClient>) {
+    render(
+      <ClientContext.Provider value={client as CrossMeClient}>
+        <UserProvider>
+          <MemoryRouter initialEntries={["/puzzles"]}>
+            <Routes>
+              <Route path="/puzzles" element={<Puzzles />} />
+            </Routes>
+          </MemoryRouter>
+        </UserProvider>
+      </ClientContext.Provider>
+    );
+  }
+
+  it("links each played puzzle to the caller's game", async () => {
+    const played = [
+      create(PuzzleIndexSchema, {
+        ...index[0],
+        game: create(PuzzleIndex_GameSchema, {
+          id: "g-solved",
+          lastPlayed: timestampFromDate(new Date("2026-09-04T12:00:00Z")),
+          completedAt: timestampFromDate(new Date("2026-09-04T13:00:00Z")),
+        }),
+      }),
+      create(PuzzleIndexSchema, {
+        ...index[1],
+        game: create(PuzzleIndex_GameSchema, {
+          id: "g-open",
+          lastPlayed: timestampFromDate(new Date("2026-09-02T12:00:00Z")),
+        }),
+      }),
+      index[2],
+    ];
+    const getPuzzleIndex = vi
+      .fn()
+      .mockResolvedValue(
+        create(GetPuzzleIndexResponseSchema, { puzzles: played })
+      );
+    renderSignedIn({ getSelf: signedInSelf(), getPuzzleIndex });
+
+    expect(
+      await screen.findByRole("link", { name: "Solved: Thursday Themeless" })
+    ).toHaveAttribute("href", "/game/g-solved");
+    expect(
+      screen.getByRole("link", { name: "In progress: Labor Day Special" })
+    ).toHaveAttribute("href", "/game/g-open");
+    // Unplayed puzzles get no game link.
+    const row = screen.getByRole("link", { name: "Summer Fun" }).closest("li")!;
+    expect(
+      within(row).queryByRole("link", { name: /Solved|In progress/ })
+    ).toBeNull();
+    // The "Solve" button still starts a fresh game on every row.
+    expect(screen.getAllByRole("button", { name: /^Solve/ })).toHaveLength(3);
+  });
 });

--- a/client/src/components/puzzles.tsx
+++ b/client/src/components/puzzles.tsx
@@ -4,10 +4,14 @@ import Button from "react-bootstrap/Button";
 import Form from "react-bootstrap/Form";
 import { Link, NavigateFunction, useNavigate } from "react-router";
 
+import { timestampDate, type Timestamp } from "@bufbuild/protobuf/wkt";
+
 import type { UploadPuzzleResponse } from "../pb/crossme_pb";
-import type { PuzzleIndex } from "../pb/puzzle_pb";
+import type { PuzzleIndex, PuzzleIndex_Game } from "../pb/puzzle_pb";
 import { dayParts, groupByMonth, matchesQuery } from "../puzzle_index";
+import { ensureSynced } from "../recent_games_sync";
 import { useClient, type CrossMeClient } from "../rpc";
+import { useUser } from "../user";
 
 import "./style/puzzles.css";
 
@@ -108,6 +112,91 @@ const PuzzleDay = ({ date }: { date: string }) => {
   );
 };
 
+// A 4x4 crossword grid, 16 units square. `filled` marks the cells (by
+// index, row-major) that read as written in; the rest are blank, and two
+// are black squares so it reads as a crossword rather than a table.
+const GridIcon = ({ filled }: { filled: number[] }) => {
+  const black = [5, 10];
+  const cells = [];
+  for (let i = 0; i < 16; i++) {
+    const x = (i % 4) * 4;
+    const y = Math.floor(i / 4) * 4;
+    if (black.includes(i)) {
+      cells.push(
+        <rect key={i} className="black" x={x} y={y} width="4" height="4" />
+      );
+    } else if (filled.includes(i)) {
+      cells.push(
+        <rect key={i} className="filled" x={x} y={y} width="4" height="4" />
+      );
+    }
+  }
+  return (
+    <>
+      {cells}
+      <path
+        className="lines"
+        d="M4 0v16M8 0v16M12 0v16M0 4h16M0 8h16M0 12h16M0.5 0.5h15v15h-15z"
+      />
+    </>
+  );
+};
+
+function formatDate(ts: Timestamp): string {
+  return timestampDate(ts).toLocaleDateString(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+}
+
+// The caller's game of a puzzle: a grid with a green check for a solved
+// game, or a half-filled grid for one in progress. Links to the game.
+const GameStatus = ({
+  game,
+  title,
+}: {
+  game: PuzzleIndex_Game;
+  title: string;
+}) => {
+  const solved = game.completedAt !== undefined;
+  const label = solved ? `Solved: ${title}` : `In progress: ${title}`;
+  const when = game.completedAt
+    ? `Solved ${formatDate(game.completedAt)}`
+    : game.lastPlayed
+      ? `In progress, last played ${formatDate(game.lastPlayed)}`
+      : undefined;
+  return (
+    <Link
+      to={`/game/${game.id}`}
+      className={`game-status ${solved ? "solved" : "in-progress"}`}
+      aria-label={label}
+      title={when}
+    >
+      <svg viewBox="0 0 20 20" width="1.5em" height="1.5em" aria-hidden="true">
+        {solved ? (
+          <>
+            <GridIcon
+              filled={[0, 1, 2, 3, 4, 6, 7, 8, 9, 11, 12, 13, 14, 15]}
+            />
+            <circle className="check-bg" cx="15" cy="15" r="5" />
+            <path
+              className="check"
+              d="M12.2 15.2l1.9 1.9 3.7-3.9"
+              fill="none"
+              strokeWidth="1.6"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+          </>
+        ) : (
+          <GridIcon filled={[0, 1, 2, 4, 8, 9, 12]} />
+        )}
+      </svg>
+    </Link>
+  );
+};
+
 const PuzzleRow = ({ puzzle }: { puzzle: PuzzleIndex }) => {
   const client = useClient();
   const navigate = useNavigate();
@@ -141,6 +230,12 @@ const PuzzleRow = ({ puzzle }: { puzzle: PuzzleIndex }) => {
           <span className="author">{byline(puzzle.author)}</span>
         )}
       </span>
+      {puzzle.game && (
+        <GameStatus
+          game={puzzle.game}
+          title={puzzle.title || "Untitled puzzle"}
+        />
+      )}
       <Button
         size="sm"
         variant="primary"
@@ -156,32 +251,42 @@ const PuzzleRow = ({ puzzle }: { puzzle: PuzzleIndex }) => {
 
 // Every puzzle on the server, newest first and grouped by month, with a
 // search box that narrows the list as you type. Each row links to the
-// puzzle's preview and can start a game directly.
+// puzzle's preview and can start a game directly; for a signed-in user,
+// rows for puzzles they have played also link to their game.
 export const Puzzles = () => {
   const client = useClient();
+  const { user } = useUser();
   const [index, setIndex] = useState<null | PuzzleIndex[]>(null);
   const [error, setError] = useState(false);
   const [query, setQuery] = useState("");
 
+  // Refetch on sign-in/sign-out: the index carries the caller's games,
+  // so the same RPC answers differently depending on the session.
+  const userId = user?.id;
   useEffect(() => {
     let cancelled = false;
-    client.getPuzzleIndex({}).then(
-      (resp) => {
-        if (!cancelled) {
-          setIndex(resp.puzzles);
+    // Fold this browser's pre-sign-in games into the account first, so
+    // they show up on the list right away.
+    const synced = userId ? ensureSynced(client, userId) : Promise.resolve();
+    synced
+      .then(() => client.getPuzzleIndex({}))
+      .then(
+        (resp) => {
+          if (!cancelled) {
+            setIndex(resp.puzzles);
+          }
+        },
+        (err) => {
+          console.log("unable to load puzzle index: ", err);
+          if (!cancelled) {
+            setError(true);
+          }
         }
-      },
-      (err) => {
-        console.log("unable to load puzzle index: ", err);
-        if (!cancelled) {
-          setError(true);
-        }
-      }
-    );
+      );
     return () => {
       cancelled = true;
     };
-  }, [client]);
+  }, [client, userId]);
 
   const groups = useMemo(
     () => groupByMonth((index ?? []).filter((puz) => matchesQuery(puz, query))),

--- a/client/src/components/style/puzzles.css
+++ b/client/src/components/style/puzzles.css
@@ -61,6 +61,44 @@
   white-space: nowrap;
 }
 
+/* The caller's own game of the puzzle: a little crossword grid, half
+   filled while the game is in progress, fully filled with a green check
+   once solved. */
+#puzzles .puzzle-row .game-status {
+  flex: 0 0 auto;
+  display: flex;
+  color: #555;
+}
+
+#puzzles .puzzle-row .game-status:hover {
+  color: var(--bs-primary);
+}
+
+#puzzles .puzzle-row .game-status .lines {
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 1;
+}
+
+#puzzles .puzzle-row .game-status .black {
+  fill: currentColor;
+}
+
+#puzzles .puzzle-row .game-status .filled {
+  fill: currentColor;
+  opacity: 0.25;
+}
+
+#puzzles .puzzle-row .game-status .check-bg {
+  fill: var(--bs-success);
+  stroke: #fff;
+  stroke-width: 1.5;
+}
+
+#puzzles .puzzle-row .game-status .check {
+  stroke: #fff;
+}
+
 #puzzles .puzzle-row .author {
   font-size: 90%;
   color: #666;

--- a/client/src/pb/puzzle_pb.ts
+++ b/client/src/pb/puzzle_pb.ts
@@ -12,7 +12,7 @@ import type { Message } from "@bufbuild/protobuf";
  * Describes the file puzzle.proto.
  */
 export const file_puzzle: GenFile = /*@__PURE__*/
-  fileDesc("CgxwdXp6bGUucHJvdG8SB2Nyb3NzbWUi/wMKBlB1enpsZRINCgV0aXRsZRgBIAEoCRIOCgZhdXRob3IYAiABKAkSEQoJY29weXJpZ2h0GAMgASgJEgwKBG5vdGUYBCABKAkSDQoFd2lkdGgYBSABKAUSDgoGaGVpZ2h0GAYgASgFEiUKB3NxdWFyZXMYCCADKAsyFC5jcm9zc21lLlB1enpsZS5DZWxsEioKDGFjcm9zc19jbHVlcxgJIAMoCzIULmNyb3NzbWUuUHV6emxlLkNsdWUSKAoKZG93bl9jbHVlcxgKIAMoCzIULmNyb3NzbWUuUHV6emxlLkNsdWUSJgoIbWV0YWRhdGEYCyABKAsyFC5jcm9zc21lLlB1enpsZS5NZXRhGmwKBENlbGwSDgoGbnVtYmVyGAEgASgFEg0KBWJsYWNrGAIgASgIEg8KB2NpcmNsZWQYAyABKAgSDAoEZmlsbBgEIAEoCRITCgtjbHVlX2Fjcm9zcxgFIAEoBRIRCgljbHVlX2Rvd24YBiABKAUaJAoEQ2x1ZRIOCgZudW1iZXIYASABKAUSDAoEdGV4dBgDIAEoCRpdCgRNZXRhEisKB2NyZWF0ZWQYASABKAsyGi5nb29nbGUucHJvdG9idWYuVGltZXN0YW1wEg4KBnNoYTI1NhgCIAEoCRIKCgJpZBgFIAEoCRIMCgRkYXRlGAMgASgJIkYKC1B1enpsZUluZGV4EgoKAmlkGAEgASgJEg0KBXRpdGxlGAIgASgJEgwKBGRhdGUYAyABKAkSDgoGYXV0aG9yGAQgASgJQhRaEmNyb3NzbWUuYXBwL3NyYy9wYmIGcHJvdG8z", [file_google_protobuf_timestamp]);
+  fileDesc("CgxwdXp6bGUucHJvdG8SB2Nyb3NzbWUi/wMKBlB1enpsZRINCgV0aXRsZRgBIAEoCRIOCgZhdXRob3IYAiABKAkSEQoJY29weXJpZ2h0GAMgASgJEgwKBG5vdGUYBCABKAkSDQoFd2lkdGgYBSABKAUSDgoGaGVpZ2h0GAYgASgFEiUKB3NxdWFyZXMYCCADKAsyFC5jcm9zc21lLlB1enpsZS5DZWxsEioKDGFjcm9zc19jbHVlcxgJIAMoCzIULmNyb3NzbWUuUHV6emxlLkNsdWUSKAoKZG93bl9jbHVlcxgKIAMoCzIULmNyb3NzbWUuUHV6emxlLkNsdWUSJgoIbWV0YWRhdGEYCyABKAsyFC5jcm9zc21lLlB1enpsZS5NZXRhGmwKBENlbGwSDgoGbnVtYmVyGAEgASgFEg0KBWJsYWNrGAIgASgIEg8KB2NpcmNsZWQYAyABKAgSDAoEZmlsbBgEIAEoCRITCgtjbHVlX2Fjcm9zcxgFIAEoBRIRCgljbHVlX2Rvd24YBiABKAUaJAoEQ2x1ZRIOCgZudW1iZXIYASABKAUSDAoEdGV4dBgDIAEoCRpdCgRNZXRhEisKB2NyZWF0ZWQYASABKAsyGi5nb29nbGUucHJvdG9idWYuVGltZXN0YW1wEg4KBnNoYTI1NhgCIAEoCRIKCgJpZBgFIAEoCRIMCgRkYXRlGAMgASgJIuYBCgtQdXp6bGVJbmRleBIKCgJpZBgBIAEoCRINCgV0aXRsZRgCIAEoCRIMCgRkYXRlGAMgASgJEg4KBmF1dGhvchgEIAEoCRInCgRnYW1lGAUgASgLMhkuY3Jvc3NtZS5QdXp6bGVJbmRleC5HYW1lGnUKBEdhbWUSCgoCaWQYASABKAkSLwoLbGFzdF9wbGF5ZWQYAiABKAsyGi5nb29nbGUucHJvdG9idWYuVGltZXN0YW1wEjAKDGNvbXBsZXRlZF9hdBgDIAEoCzIaLmdvb2dsZS5wcm90b2J1Zi5UaW1lc3RhbXBCFFoSY3Jvc3NtZS5hcHAvc3JjL3BiYgZwcm90bzM", [file_google_protobuf_timestamp]);
 
 /**
  * @generated from message crossme.Puzzle
@@ -202,6 +202,17 @@ export type PuzzleIndex = Message<"crossme.PuzzleIndex"> & {
    * @generated from field: string author = 4;
    */
   author: string;
+
+  /**
+   * The caller's own game of this puzzle, so the list can link back
+   * to it. Unset for anonymous callers, and for puzzles the caller has
+   * not played. A user who has played a puzzle more than once gets a
+   * single game here: a solved one if there is one, otherwise the most
+   * recently played.
+   *
+   * @generated from field: crossme.PuzzleIndex.Game game = 5;
+   */
+  game?: PuzzleIndex_Game | undefined;
 };
 
 /**
@@ -210,4 +221,35 @@ export type PuzzleIndex = Message<"crossme.PuzzleIndex"> & {
  */
 export const PuzzleIndexSchema: GenMessage<PuzzleIndex> = /*@__PURE__*/
   messageDesc(file_puzzle, 1);
+
+/**
+ * @generated from message crossme.PuzzleIndex.Game
+ */
+export type PuzzleIndex_Game = Message<"crossme.PuzzleIndex.Game"> & {
+  /**
+   * @generated from field: string id = 1;
+   */
+  id: string;
+
+  /**
+   * When the caller last opened the game.
+   *
+   * @generated from field: google.protobuf.Timestamp last_played = 2;
+   */
+  lastPlayed?: Timestamp | undefined;
+
+  /**
+   * Set once the game has been solved; unset while in progress.
+   *
+   * @generated from field: google.protobuf.Timestamp completed_at = 3;
+   */
+  completedAt?: Timestamp | undefined;
+};
+
+/**
+ * Describes the message crossme.PuzzleIndex.Game.
+ * Use `create(PuzzleIndex_GameSchema)` to create a new message.
+ */
+export const PuzzleIndex_GameSchema: GenMessage<PuzzleIndex_Game> = /*@__PURE__*/
+  messageDesc(file_puzzle, 1, 0);
 

--- a/pb/puzzle.pb.go
+++ b/pb/puzzle.pb.go
@@ -139,11 +139,17 @@ func (x *Puzzle) GetMetadata() *Puzzle_Meta {
 }
 
 type PuzzleIndex struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Id            string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
-	Title         string                 `protobuf:"bytes,2,opt,name=title,proto3" json:"title,omitempty"`
-	Date          string                 `protobuf:"bytes,3,opt,name=date,proto3" json:"date,omitempty"`
-	Author        string                 `protobuf:"bytes,4,opt,name=author,proto3" json:"author,omitempty"`
+	state  protoimpl.MessageState `protogen:"open.v1"`
+	Id     string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	Title  string                 `protobuf:"bytes,2,opt,name=title,proto3" json:"title,omitempty"`
+	Date   string                 `protobuf:"bytes,3,opt,name=date,proto3" json:"date,omitempty"`
+	Author string                 `protobuf:"bytes,4,opt,name=author,proto3" json:"author,omitempty"`
+	// The caller's own game of this puzzle, so the list can link back
+	// to it. Unset for anonymous callers, and for puzzles the caller has
+	// not played. A user who has played a puzzle more than once gets a
+	// single game here: a solved one if there is one, otherwise the most
+	// recently played.
+	Game          *PuzzleIndex_Game `protobuf:"bytes,5,opt,name=game,proto3" json:"game,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -204,6 +210,13 @@ func (x *PuzzleIndex) GetAuthor() string {
 		return x.Author
 	}
 	return ""
+}
+
+func (x *PuzzleIndex) GetGame() *PuzzleIndex_Game {
+	if x != nil {
+		return x.Game
+	}
+	return nil
 }
 
 type Puzzle_Cell struct {
@@ -414,6 +427,68 @@ func (x *Puzzle_Meta) GetDate() string {
 	return ""
 }
 
+type PuzzleIndex_Game struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	Id    string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	// When the caller last opened the game.
+	LastPlayed *timestamppb.Timestamp `protobuf:"bytes,2,opt,name=last_played,json=lastPlayed,proto3" json:"last_played,omitempty"`
+	// Set once the game has been solved; unset while in progress.
+	CompletedAt   *timestamppb.Timestamp `protobuf:"bytes,3,opt,name=completed_at,json=completedAt,proto3" json:"completed_at,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *PuzzleIndex_Game) Reset() {
+	*x = PuzzleIndex_Game{}
+	mi := &file_puzzle_proto_msgTypes[5]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PuzzleIndex_Game) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PuzzleIndex_Game) ProtoMessage() {}
+
+func (x *PuzzleIndex_Game) ProtoReflect() protoreflect.Message {
+	mi := &file_puzzle_proto_msgTypes[5]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use PuzzleIndex_Game.ProtoReflect.Descriptor instead.
+func (*PuzzleIndex_Game) Descriptor() ([]byte, []int) {
+	return file_puzzle_proto_rawDescGZIP(), []int{1, 0}
+}
+
+func (x *PuzzleIndex_Game) GetId() string {
+	if x != nil {
+		return x.Id
+	}
+	return ""
+}
+
+func (x *PuzzleIndex_Game) GetLastPlayed() *timestamppb.Timestamp {
+	if x != nil {
+		return x.LastPlayed
+	}
+	return nil
+}
+
+func (x *PuzzleIndex_Game) GetCompletedAt() *timestamppb.Timestamp {
+	if x != nil {
+		return x.CompletedAt
+	}
+	return nil
+}
+
 var File_puzzle_proto protoreflect.FileDescriptor
 
 const file_puzzle_proto_rawDesc = "" +
@@ -447,12 +522,18 @@ const file_puzzle_proto_rawDesc = "" +
 	"\acreated\x18\x01 \x01(\v2\x1a.google.protobuf.TimestampR\acreated\x12\x16\n" +
 	"\x06sha256\x18\x02 \x01(\tR\x06sha256\x12\x0e\n" +
 	"\x02id\x18\x05 \x01(\tR\x02id\x12\x12\n" +
-	"\x04date\x18\x03 \x01(\tR\x04date\"_\n" +
+	"\x04date\x18\x03 \x01(\tR\x04date\"\xa3\x02\n" +
 	"\vPuzzleIndex\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x14\n" +
 	"\x05title\x18\x02 \x01(\tR\x05title\x12\x12\n" +
 	"\x04date\x18\x03 \x01(\tR\x04date\x12\x16\n" +
-	"\x06author\x18\x04 \x01(\tR\x06authorB\x14Z\x12crossme.app/src/pbb\x06proto3"
+	"\x06author\x18\x04 \x01(\tR\x06author\x12-\n" +
+	"\x04game\x18\x05 \x01(\v2\x19.crossme.PuzzleIndex.GameR\x04game\x1a\x92\x01\n" +
+	"\x04Game\x12\x0e\n" +
+	"\x02id\x18\x01 \x01(\tR\x02id\x12;\n" +
+	"\vlast_played\x18\x02 \x01(\v2\x1a.google.protobuf.TimestampR\n" +
+	"lastPlayed\x12=\n" +
+	"\fcompleted_at\x18\x03 \x01(\v2\x1a.google.protobuf.TimestampR\vcompletedAtB\x14Z\x12crossme.app/src/pbb\x06proto3"
 
 var (
 	file_puzzle_proto_rawDescOnce sync.Once
@@ -466,26 +547,30 @@ func file_puzzle_proto_rawDescGZIP() []byte {
 	return file_puzzle_proto_rawDescData
 }
 
-var file_puzzle_proto_msgTypes = make([]protoimpl.MessageInfo, 5)
+var file_puzzle_proto_msgTypes = make([]protoimpl.MessageInfo, 6)
 var file_puzzle_proto_goTypes = []any{
 	(*Puzzle)(nil),                // 0: crossme.Puzzle
 	(*PuzzleIndex)(nil),           // 1: crossme.PuzzleIndex
 	(*Puzzle_Cell)(nil),           // 2: crossme.Puzzle.Cell
 	(*Puzzle_Clue)(nil),           // 3: crossme.Puzzle.Clue
 	(*Puzzle_Meta)(nil),           // 4: crossme.Puzzle.Meta
-	(*timestamppb.Timestamp)(nil), // 5: google.protobuf.Timestamp
+	(*PuzzleIndex_Game)(nil),      // 5: crossme.PuzzleIndex.Game
+	(*timestamppb.Timestamp)(nil), // 6: google.protobuf.Timestamp
 }
 var file_puzzle_proto_depIdxs = []int32{
 	2, // 0: crossme.Puzzle.squares:type_name -> crossme.Puzzle.Cell
 	3, // 1: crossme.Puzzle.across_clues:type_name -> crossme.Puzzle.Clue
 	3, // 2: crossme.Puzzle.down_clues:type_name -> crossme.Puzzle.Clue
 	4, // 3: crossme.Puzzle.metadata:type_name -> crossme.Puzzle.Meta
-	5, // 4: crossme.Puzzle.Meta.created:type_name -> google.protobuf.Timestamp
-	5, // [5:5] is the sub-list for method output_type
-	5, // [5:5] is the sub-list for method input_type
-	5, // [5:5] is the sub-list for extension type_name
-	5, // [5:5] is the sub-list for extension extendee
-	0, // [0:5] is the sub-list for field type_name
+	5, // 4: crossme.PuzzleIndex.game:type_name -> crossme.PuzzleIndex.Game
+	6, // 5: crossme.Puzzle.Meta.created:type_name -> google.protobuf.Timestamp
+	6, // 6: crossme.PuzzleIndex.Game.last_played:type_name -> google.protobuf.Timestamp
+	6, // 7: crossme.PuzzleIndex.Game.completed_at:type_name -> google.protobuf.Timestamp
+	8, // [8:8] is the sub-list for method output_type
+	8, // [8:8] is the sub-list for method input_type
+	8, // [8:8] is the sub-list for extension type_name
+	8, // [8:8] is the sub-list for extension extendee
+	0, // [0:8] is the sub-list for field type_name
 }
 
 func init() { file_puzzle_proto_init() }
@@ -499,7 +584,7 @@ func file_puzzle_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_puzzle_proto_rawDesc), len(file_puzzle_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   5,
+			NumMessages:   6,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/pb/puzzle.proto
+++ b/pb/puzzle.proto
@@ -53,4 +53,19 @@ message PuzzleIndex {
     string title = 2;
     string date = 3;
     string author = 4;
+
+    // The caller's own game of this puzzle, so the list can link back
+    // to it. Unset for anonymous callers, and for puzzles the caller has
+    // not played. A user who has played a puzzle more than once gets a
+    // single game here: a solved one if there is one, otherwise the most
+    // recently played.
+    Game game = 5;
+
+    message Game {
+        string id = 1;
+        // When the caller last opened the game.
+        google.protobuf.Timestamp last_played = 2;
+        // Set once the game has been solved; unset while in progress.
+        google.protobuf.Timestamp completed_at = 3;
+    }
 }

--- a/repo/games_test.go
+++ b/repo/games_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	_ "github.com/mattn/go-sqlite3"
+	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"crossme.app/src/pb"
 	"crossme.app/src/puz"
@@ -154,5 +155,115 @@ func TestPlayHistory(t *testing.T) {
 	// Other users' histories are unaffected.
 	if games := gamesForUser(t, r, "user-2"); len(games) != 0 {
 		t.Fatalf("history leaked across users: %v", games)
+	}
+}
+
+// puzzleGame returns the game attached to `puzzleId` in the index as seen
+// by `user`, or nil if there is none.
+func puzzleGame(t *testing.T, r *Repository, user, puzzleId string) *pb.PuzzleIndex_Game {
+	t.Helper()
+	index, err := r.PuzzleIndex(user)
+	if err != nil {
+		t.Fatalf("PuzzleIndex(%q): %v", user, err)
+	}
+	for _, puz := range index {
+		if puz.Id == puzzleId {
+			return puz.Game
+		}
+	}
+	t.Fatalf("puzzle %q missing from the index", puzzleId)
+	return nil
+}
+
+func TestPuzzleIndexGames(t *testing.T) {
+	t.Parallel()
+	r, err := Open(":memory:")
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer r.Close()
+
+	puzzleId := insertTestPuzzle(t, r, "nyt_sun_rebus.puz")
+	otherId := insertTestPuzzle(t, r, "nyt_weekday_with_notes.puz")
+
+	// Nothing played yet: no game on either puzzle, for anyone.
+	const user = "user-1"
+	for _, u := range []string{"", user} {
+		for _, p := range []string{puzzleId, otherId} {
+			if g := puzzleGame(t, r, u, p); g != nil {
+				t.Errorf("user %q, puzzle %q: unexpected game %v", u, p, g)
+			}
+		}
+	}
+
+	newGame := func() *pb.Game {
+		game, err := r.NewGame(puzzleId, "")
+		if err != nil {
+			t.Fatalf("NewGame: %v", err)
+		}
+		return game
+	}
+	playAt := func(game *pb.Game, at time.Time) {
+		if err := r.RecordPlayAt(game.Id, user, at); err != nil {
+			t.Fatalf("RecordPlayAt: %v", err)
+		}
+	}
+	t0 := time.Date(2001, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	// One in-progress game: that's the one.
+	old := newGame()
+	playAt(old, t0)
+	got := puzzleGame(t, r, user, puzzleId)
+	if got == nil || got.Id != old.Id {
+		t.Fatalf("game = %v, want %s", got, old.Id)
+	}
+	if !got.LastPlayed.AsTime().Equal(t0) {
+		t.Errorf("last_played = %v, want %v", got.LastPlayed.AsTime(), t0)
+	}
+	if got.CompletedAt != nil {
+		t.Errorf("in-progress game marked complete: %v", got)
+	}
+	// ...but only for the player: other users and anonymous callers
+	// see nothing, and the other puzzle is untouched.
+	if g := puzzleGame(t, r, "", puzzleId); g != nil {
+		t.Errorf("anonymous caller sees a game: %v", g)
+	}
+	if g := puzzleGame(t, r, "user-2", puzzleId); g != nil {
+		t.Errorf("another user sees the game: %v", g)
+	}
+	if g := puzzleGame(t, r, user, otherId); g != nil {
+		t.Errorf("game attached to the wrong puzzle: %v", g)
+	}
+
+	// Among in-progress games, the most recently played wins.
+	recent := newGame()
+	playAt(recent, t0.Add(time.Hour))
+	if got := puzzleGame(t, r, user, puzzleId); got.Id != recent.Id {
+		t.Errorf("game = %s, want the more recent %s", got.Id, recent.Id)
+	}
+
+	// A solved game beats any in-progress one, however stale.
+	solved := newGame()
+	playAt(solved, t0.Add(-time.Hour))
+	solved.CompletedAt = timestamppb.New(t0)
+	if err := r.UpdateGame(solved); err != nil {
+		t.Fatalf("UpdateGame: %v", err)
+	}
+	got = puzzleGame(t, r, user, puzzleId)
+	if got.Id != solved.Id {
+		t.Errorf("game = %s, want the solved %s", got.Id, solved.Id)
+	}
+	if got.CompletedAt == nil || !got.CompletedAt.AsTime().Equal(t0) {
+		t.Errorf("completed_at = %v, want %v", got.CompletedAt, t0)
+	}
+
+	// A game the user never opened doesn't count, even if solved.
+	unplayed := newGame()
+	unplayed.CompletedAt = timestamppb.New(t0.Add(time.Hour))
+	if err := r.UpdateGame(unplayed); err != nil {
+		t.Fatalf("UpdateGame: %v", err)
+	}
+	if got := puzzleGame(t, r, user, puzzleId); got.Id != solved.Id {
+		t.Errorf("game = %s, want the played %s", got.Id, solved.Id)
 	}
 }

--- a/repo/migrate_test.go
+++ b/repo/migrate_test.go
@@ -136,7 +136,7 @@ func TestMigrateForward(t *testing.T) {
 		t.Errorf("games table lacks completed_at after migration: %v", cols)
 	}
 
-	index, err := repo.PuzzleIndex()
+	index, err := repo.PuzzleIndex("")
 	if err != nil {
 		t.Fatalf("PuzzleIndex: %v", err)
 	}

--- a/repo/query.go
+++ b/repo/query.go
@@ -15,19 +15,42 @@ var (
 	ErrNoSuchSession = errors.New("no such session")
 )
 
-func (r *Repository) PuzzleIndex() ([]*pb.PuzzleIndex, error) {
-	var out []*pb.PuzzleIndex
-	rows, err := r.db.Query(sql_query_puzzle_index)
+// PuzzleIndex lists every puzzle, newest first. user_id is the caller,
+// whose own game of each puzzle (if any) is attached to the entry; pass ""
+// for an anonymous caller, who gets the bare index.
+func (r *Repository) PuzzleIndex(user_id string) ([]*pb.PuzzleIndex, error) {
+	rows, err := r.db.NamedQuery(sql_query_puzzle_index, query_puzzle_index_args{
+		UserId: user_id,
+	})
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
+	var out []*pb.PuzzleIndex
 	for rows.Next() {
-		var puz pb.PuzzleIndex
-		if err := rows.Scan(&puz.Id, &puz.Title, &puz.Author, &puz.Date); err != nil {
+		var row puzzle_index_row
+		if err := rows.StructScan(&row); err != nil {
 			return nil, err
 		}
-		out = append(out, &puz)
+		puz := &pb.PuzzleIndex{
+			Id:     row.Id,
+			Title:  row.Title,
+			Author: row.Author,
+			Date:   row.Date,
+		}
+		if row.GameId.Valid {
+			game := &pb.PuzzleIndex_Game{Id: row.GameId.String}
+			if game.LastPlayed, err = parseTimestamp(row.LastPlayed.String); err != nil {
+				return nil, err
+			}
+			if row.CompletedAt.Valid {
+				if game.CompletedAt, err = parseTimestamp(row.CompletedAt.String); err != nil {
+					return nil, err
+				}
+			}
+			puz.Game = game
+		}
+		out = append(out, puz)
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err

--- a/repo/repo_test.go
+++ b/repo/repo_test.go
@@ -88,7 +88,7 @@ func TestInsertQuery(t *testing.T) {
 		t.Fatalf("duplicate ids: %#v", ids)
 	}
 
-	index, err := repo.PuzzleIndex()
+	index, err := repo.PuzzleIndex("")
 	if err != nil {
 		t.Fatalf("PuzzleIndex: %v", err)
 	}

--- a/repo/sql.go
+++ b/repo/sql.go
@@ -28,11 +28,52 @@ type insert_puzzle_args struct {
 	Created string         `db:"created"`
 }
 
+// The index, with the caller's own game of each puzzle attached where
+// there is one. A user who has played a puzzle more than once gets a single
+// game: a solved one if there is one, otherwise the most recently played,
+// with the game id as a tiebreak so the choice is stable. An empty user id
+// (an anonymous caller) matches no plays, so every game column is NULL.
 const sql_query_puzzle_index = `
-SELECT meta__id as id, title, author, meta__date as date
+WITH my_games AS (
+  SELECT games.puzzle_id AS puzzle_id,
+         games.id AS game_id,
+         game_players.last_played AS last_played,
+         games.completed_at AS completed_at,
+         row_number() OVER (
+           PARTITION BY games.puzzle_id
+           ORDER BY games.completed_at IS NOT NULL DESC,
+                    game_players.last_played DESC,
+                    games.id
+         ) AS rank
+  FROM game_players
+  JOIN games ON games.id = game_players.game_id
+  WHERE game_players.user_id = :user_id
+)
+SELECT puzzles.meta__id AS id,
+       puzzles.title AS title,
+       puzzles.author AS author,
+       puzzles.meta__date AS date,
+       my_games.game_id AS game_id,
+       my_games.last_played AS last_played,
+       my_games.completed_at AS completed_at
 FROM puzzles
+LEFT JOIN my_games ON my_games.puzzle_id = puzzles.meta__id AND my_games.rank = 1
 ORDER BY date DESC, title
 `
+
+type query_puzzle_index_args struct {
+	UserId string `db:"user_id"`
+}
+
+type puzzle_index_row struct {
+	Id          string         `db:"id"`
+	Title       string         `db:"title"`
+	Author      string         `db:"author"`
+	Date        string         `db:"date"`
+	GameId      sql.NullString `db:"game_id"`
+	LastPlayed  sql.NullString `db:"last_played"`
+	CompletedAt sql.NullString `db:"completed_at"`
+}
 
 const sql_query_puzzle_by_id = `
 SELECT proto

--- a/server/mygames_test.go
+++ b/server/mygames_test.go
@@ -7,6 +7,7 @@ import (
 
 	"connectrpc.com/connect"
 	"crossme.app/src/pb"
+	"crossme.app/src/pb/pbconnect"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
@@ -138,4 +139,52 @@ func TestRecordPlays(t *testing.T) {
 		},
 	}))
 	must(t, "anonymous RecordPlays", err)
+}
+
+func TestPuzzleIndexGames(t *testing.T) {
+	ctx := context.Background()
+	ts, puz := makeServerWithPuzzle(t, "nyt_weekday_with_notes")
+	defer ts.Stop()
+
+	indexGame := func(client pbconnect.CrossMeClient) *pb.PuzzleIndex_Game {
+		t.Helper()
+		resp, err := client.GetPuzzleIndex(ctx, connect.NewRequest(&pb.GetPuzzleIndexArgs{}))
+		must(t, "GetPuzzleIndex", err)
+		if len(resp.Msg.Puzzles) != 1 {
+			t.Fatalf("index: %v", resp.Msg.Puzzles)
+		}
+		return resp.Msg.Puzzles[0].Game
+	}
+
+	anon := ts.Dial()
+	ada, _ := ts.DialAs("ada")
+	g, err := ada.NewGame(ctx, connect.NewRequest(&pb.NewGameArgs{PuzzleId: puz.Metadata.Id}))
+	must(t, "NewGame", err)
+	gameId := g.Msg.Game.Id
+	_, err = ada.GetGameById(ctx, connect.NewRequest(&pb.GetGameByIdArgs{Id: gameId}))
+	must(t, "GetGameById", err)
+
+	// The player sees their in-progress game; an anonymous caller sees
+	// no games at all.
+	got := indexGame(ada)
+	if got == nil || got.Id != gameId {
+		t.Fatalf("ada's index game = %v, want %s", got, gameId)
+	}
+	if got.CompletedAt != nil || got.LastPlayed == nil {
+		t.Errorf("ada's index game: %v", got)
+	}
+	if got := indexGame(anon); got != nil {
+		t.Errorf("anonymous index carries a game: %v", got)
+	}
+
+	// Solving it flips the entry to completed.
+	_, err = ada.UpdateFill(ctx, connect.NewRequest(&pb.UpdateFillArgs{
+		GameId: gameId,
+		NodeId: "node1",
+		Fill:   solvedFill(puz, 1),
+	}))
+	must(t, "UpdateFill", err)
+	if got := indexGame(ada); got == nil || got.Id != gameId || got.CompletedAt == nil {
+		t.Errorf("solved game not marked in the index: %v", got)
+	}
 }

--- a/server/server.go
+++ b/server/server.go
@@ -73,7 +73,9 @@ type clientState struct {
 }
 
 func (s *Server) GetPuzzleIndex(ctx context.Context, req *connect.Request[pb.GetPuzzleIndexArgs]) (*connect.Response[pb.GetPuzzleIndexResponse], error) {
-	index, err := s.repo.PuzzleIndex()
+	// A signed-in caller gets their own game of each puzzle attached;
+	// an anonymous one just gets the index.
+	index, err := s.repo.PuzzleIndex(auth.UserFromContext(ctx).GetId())
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary
Add the ability to display a player's game status (solved or in-progress) directly on the puzzle list, with links to their existing games. This allows signed-in users to quickly see which puzzles they've played and resume them without navigating to the puzzle details page.

## Key Changes

**Protobuf & Database Schema**
- Added `PuzzleIndex.Game` message type to carry game metadata (id, last_played, completed_at)
- Extended `PuzzleIndex` proto message with optional `game` field
- Updated SQL query to LEFT JOIN against the caller's games, selecting the most recently played game (or solved game if available) per puzzle
- Modified `PuzzleIndex()` repository method to accept a `user_id` parameter and populate game data

**Server**
- Updated `GetPuzzleIndex` RPC handler to pass the authenticated user's ID to the repository
- Added server-side test coverage for puzzle index game attachment logic

**Client UI**
- Created `GameStatus` component that renders a 4x4 grid icon (half-filled for in-progress, fully-filled with checkmark for solved)
- Added `GridIcon` SVG component to visualize puzzle state
- Added `formatDate()` helper to format timestamps for display
- Integrated game status links into `PuzzleRow`, showing only for puzzles the user has played
- Updated puzzle list to sync pre-sign-in games to the account before fetching the index
- Added styling for game status icons with hover effects and color coding

**Tests**
- Added comprehensive test coverage in `repo/games_test.go` for puzzle index game selection logic
- Added server-side integration test in `server/mygames_test.go`
- Added client-side test in `client/src/components/puzzles.test.tsx` verifying game links appear for played puzzles

## Implementation Details

The game selection logic prioritizes solved games over in-progress ones, and among games of the same status, selects the most recently played. This ensures users see their completed work first, and can easily resume their latest attempt if still in progress.

Anonymous callers see no game data; the index is identical to before for unauthenticated requests.

https://claude.ai/code/session_013s5qfFc5GV8RZs1HskmomV