### PR TITLE
Replace the hidden mobile input with an on-screen keyboard

### DIFF
--- a/client/src/components/current_clue.tsx
+++ b/client/src/components/current_clue.tsx
@@ -1,5 +1,3 @@
-import React from "react";
-
 import { Clue, Direction } from "../types";
 
 export interface CurrentClueProps {
@@ -9,10 +7,6 @@ export interface CurrentClueProps {
   onNext: () => void;
   onToggle: () => void;
 }
-
-// Keep the grid's hidden input focused: a control that took focus on
-// tap would dismiss the mobile keyboard.
-const keepFocus = (e: React.PointerEvent) => e.preventDefault();
 
 export const CurrentClue = ({
   clue,
@@ -26,17 +20,11 @@ export const CurrentClue = ({
       type="button"
       className="clue-nav prev"
       aria-label="Previous clue"
-      onPointerDown={keepFocus}
       onClick={onPrev}
     >
       &lsaquo;
     </button>
-    <span
-      className="body"
-      title="Switch direction"
-      onPointerDown={keepFocus}
-      onClick={onToggle}
-    >
+    <span className="body" title="Switch direction" onClick={onToggle}>
       <span className="badge bg-secondary">
         <span className="number">{clue.number}</span>
         <span className="direction"> {direction}</span>
@@ -47,7 +35,6 @@ export const CurrentClue = ({
       type="button"
       className="clue-nav next"
       aria-label="Next clue"
-      onPointerDown={keepFocus}
       onClick={onNext}
     >
       &rsaquo;

--- a/client/src/components/keyboard.test.tsx
+++ b/client/src/components/keyboard.test.tsx
@@ -1,0 +1,78 @@
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import React from "react";
+
+import { Keyboard } from "./keyboard";
+
+function renderKeyboard(fill = "") {
+  const onInput = vi.fn();
+  const onDelete = vi.fn();
+  const ref = React.createRef<Keyboard>();
+  render(
+    <Keyboard ref={ref} fill={fill} onInput={onInput} onDelete={onDelete} />
+  );
+  return { onInput, onDelete, ref };
+}
+
+function key(name: string): HTMLElement {
+  return screen.getByRole("button", { name });
+}
+
+it("types letters and deletes on pointerdown", () => {
+  const { onInput, onDelete } = renderKeyboard();
+
+  fireEvent.pointerDown(key("Q"), { button: 0 });
+  fireEvent.pointerDown(key("Backspace"), { button: 0 });
+
+  expect(onInput).toHaveBeenCalledWith("Q");
+  expect(onDelete).toHaveBeenCalledTimes(1);
+});
+
+it("ignores secondary buttons", () => {
+  const { onInput } = renderKeyboard();
+
+  fireEvent.pointerDown(key("Q"), { button: 2 });
+
+  expect(onInput).not.toHaveBeenCalled();
+});
+
+it("commits free-text entry when the box closes", () => {
+  const { onInput } = renderKeyboard();
+
+  fireEvent.click(key("Other characters"));
+  const input = screen.getByRole("textbox") as HTMLInputElement;
+  expect(document.activeElement).toBe(input);
+  expect(screen.queryByRole("button", { name: "Q" })).toBeNull();
+
+  fireEvent.change(input, { target: { value: "12" } });
+  fireEvent.submit(input.closest("form") as HTMLFormElement);
+
+  expect(onInput).toHaveBeenCalledWith("12");
+  expect(screen.queryByRole("textbox")).toBeNull();
+  expect(key("Q")).toBeTruthy();
+});
+
+it("pre-fills the box with the cell's fill, and doesn't re-enter it", () => {
+  const { onInput, ref } = renderKeyboard("ONE");
+
+  act(() => ref.current?.openEntry());
+  const input = screen.getByRole("textbox") as HTMLInputElement;
+  expect(input.value).toBe("ONE");
+
+  fireEvent.blur(input);
+
+  expect(onInput).not.toHaveBeenCalled();
+  expect(screen.queryByRole("textbox")).toBeNull();
+});
+
+it("cancels entry on Escape", () => {
+  const { onInput } = renderKeyboard("ONE");
+
+  fireEvent.click(key("Other characters"));
+  const input = screen.getByRole("textbox") as HTMLInputElement;
+  fireEvent.change(input, { target: { value: "TWO" } });
+  fireEvent.keyDown(input, { key: "Escape" });
+  fireEvent.blur(input);
+
+  expect(onInput).not.toHaveBeenCalled();
+  expect(screen.queryByRole("textbox")).toBeNull();
+});

--- a/client/src/components/keyboard.tsx
+++ b/client/src/components/keyboard.tsx
@@ -1,0 +1,174 @@
+import React from "react";
+
+const ROWS = ["QWERTYUIOP", "ASDFGHJKL", "ZXCVBNM"];
+
+export interface KeyboardProps {
+  // The current fill of the selected cell; pre-fills the free-text box.
+  fill: string;
+
+  onInput: (text: string) => void;
+  onDelete: () => void;
+}
+
+interface KeyboardState {
+  // The free-text box is open in place of the letter keys.
+  entry: boolean;
+}
+
+// An on-screen keyboard for touch devices (shown by CSS only on small
+// screens). It's letters-only, which is much shorter than a device
+// keyboard; anything else -- a rebus, digits, punctuation -- goes
+// through the "..." key, which opens a text box and so brings up the
+// device keyboard for just that one entry.
+//
+// Keys act on pointerdown rather than click, so they feel as immediate
+// as a real keyboard; the keyboard is `touch-action: none`, so a touch
+// that starts on it can't be the start of a scroll. The "..." key is
+// the exception: it acts on click, because iOS will only bring up the
+// device keyboard for a focus() made from a click-like gesture.
+export class Keyboard extends React.Component<KeyboardProps, KeyboardState> {
+  root: React.RefObject<HTMLDivElement | null>;
+  entryInput: React.RefObject<HTMLInputElement | null>;
+  // Set by Escape: the box closes without committing its contents.
+  cancelled: boolean = false;
+
+  constructor(props: KeyboardProps) {
+    super(props);
+    this.state = { entry: false };
+    this.root = React.createRef();
+    this.entryInput = React.createRef();
+
+    this.onKey = this.onKey.bind(this);
+    this.onSubmit = this.onSubmit.bind(this);
+    this.onEntryBlur = this.onEntryBlur.bind(this);
+    this.onEntryKeyDown = this.onEntryKeyDown.bind(this);
+    this.openEntry = this.openEntry.bind(this);
+  }
+
+  // Whether the keyboard is currently displayed, i.e. whether CSS has
+  // decided this is a touch-sized screen. Callers use this to route
+  // free-text entry here rather than to an in-grid input, so that the
+  // breakpoint lives in one place (the stylesheet).
+  isVisible(): boolean {
+    const el = this.root.current;
+    return !!el && el.getClientRects().length > 0;
+  }
+
+  openEntry() {
+    this.cancelled = false;
+    this.setState({ entry: true });
+  }
+
+  onKey(e: React.PointerEvent<HTMLButtonElement>) {
+    // Only the main button: a right-click on desktop shouldn't type.
+    if (e.button !== 0) {
+      return;
+    }
+    const key = e.currentTarget.dataset.key;
+    if (key === undefined) {
+      return;
+    }
+    if (key === "delete") {
+      this.props.onDelete();
+    } else {
+      this.props.onInput(key);
+    }
+  }
+
+  onSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    // Committing happens on blur, so that tapping anywhere else (or
+    // the device keyboard's own Done key) also commits.
+    this.entryInput.current?.blur();
+  }
+
+  onEntryKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
+    if (e.key === "Escape") {
+      this.cancelled = true;
+      e.currentTarget.blur();
+    }
+  }
+
+  onEntryBlur(e: React.FocusEvent<HTMLInputElement>) {
+    const value = e.target.value.toUpperCase();
+    const cancelled = this.cancelled;
+    this.cancelled = false;
+    this.setState({ entry: false });
+    // Closing the box with its contents untouched is a cancel, not a
+    // (cursor-advancing) re-entry of the same fill.
+    if (!cancelled && value !== this.props.fill) {
+      this.props.onInput(value);
+    }
+  }
+
+  renderEntry() {
+    return (
+      <form className="entrybox" onSubmit={this.onSubmit}>
+        <input
+          ref={this.entryInput}
+          type="text"
+          aria-label="Cell contents"
+          defaultValue={this.props.fill}
+          autoFocus={true}
+          autoCapitalize="characters"
+          autoCorrect="off"
+          autoComplete="off"
+          spellCheck={false}
+          enterKeyHint="done"
+          onKeyDown={this.onEntryKeyDown}
+          onBlur={this.onEntryBlur}
+        />
+        <button type="submit">Done</button>
+      </form>
+    );
+  }
+
+  renderKey(key: string, label: string, name?: string) {
+    return (
+      <button
+        key={key}
+        type="button"
+        className={name ? `key ${key}` : "key"}
+        data-key={key}
+        aria-label={name}
+        onPointerDown={this.onKey}
+      >
+        {label}
+      </button>
+    );
+  }
+
+  renderKeys() {
+    const rows = ROWS.map((letters, i) => {
+      const keys = Array.from(letters, (l) => this.renderKey(l, l));
+      if (i === ROWS.length - 1) {
+        keys.unshift(
+          <button
+            key="entry"
+            type="button"
+            className="key entry"
+            aria-label="Other characters"
+            onClick={this.openEntry}
+          >
+            ...
+          </button>
+        );
+        keys.push(this.renderKey("delete", "⌫", "Backspace"));
+      }
+      return (
+        <div className="keyrow" key={i}>
+          {keys}
+        </div>
+      );
+    });
+    return <>{rows}</>;
+  }
+
+  render() {
+    return (
+      <div id="keyboard" ref={this.root}>
+        {this.state.entry ? this.renderEntry() : this.renderKeys()}
+      </div>
+    );
+  }
+}

--- a/client/src/components/puzzle.test.tsx
+++ b/client/src/components/puzzle.test.tsx
@@ -2,6 +2,7 @@ import React, { StrictMode, act } from "react";
 import { render } from "@testing-library/react";
 
 import ThePuzzle from "../puzzle";
+import * as Crossword from "../crossword";
 import { ClientContext, type CrossMeClient } from "../rpc";
 import { PuzzleComponent } from "./puzzle";
 
@@ -59,6 +60,40 @@ it("sends nothing for an edit that doesn't change the fill", () => {
   act(() => {
     puzzle.onClickCell({ row: 0, column: 1 });
   });
+
+  expect(updateFill).not.toHaveBeenCalled();
+});
+
+// Physical keyboards are handled at the window level, since there is
+// no focused input to type into.
+it("fills the selected cell from a keydown", () => {
+  const updateFill = vi.fn().mockResolvedValue({});
+  const puzzle = renderPuzzle(
+    updateFill as unknown as CrossMeClient["updateFill"]
+  );
+
+  act(() => {
+    window.dispatchEvent(new KeyboardEvent("keydown", { key: "a" }));
+  });
+
+  expect(updateFill).toHaveBeenCalledTimes(1);
+  expect(Crossword.fillAt(puzzle.state.game, { row: 0, column: 0 })?.fill).toBe(
+    "A"
+  );
+});
+
+it("leaves keystrokes aimed at a text box alone", () => {
+  const updateFill = vi.fn().mockResolvedValue({});
+  renderPuzzle(updateFill as unknown as CrossMeClient["updateFill"]);
+
+  const input = document.createElement("input");
+  document.body.appendChild(input);
+  act(() => {
+    input.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "a", bubbles: true })
+    );
+  });
+  input.remove();
 
   expect(updateFill).not.toHaveBeenCalled();
 });

--- a/client/src/components/puzzle.tsx
+++ b/client/src/components/puzzle.tsx
@@ -11,6 +11,7 @@ import { ClientContext, type CrossMeClient } from "../rpc";
 import { Metadata } from "./metadata";
 import { PuzzleGrid } from "./puzzle_grid";
 import { CurrentClue } from "./current_clue";
+import { Keyboard } from "./keyboard";
 import { ClueBox } from "./clue_box";
 import { Sidebar } from "./sidebar";
 
@@ -40,6 +41,7 @@ export class PuzzleComponent extends React.Component<PuzzleProps, PuzzleState> {
   reconnectDelay: number = 0;
 
   grid: React.RefObject<PuzzleGrid | null>;
+  keyboard: React.RefObject<Keyboard | null>;
 
   constructor(props: PuzzleProps) {
     super(props);
@@ -47,11 +49,13 @@ export class PuzzleComponent extends React.Component<PuzzleProps, PuzzleState> {
       game: Crossword.newGame(props.puzzle),
     };
     this.grid = React.createRef();
+    this.keyboard = React.createRef();
 
     this.onClickCell = this.onClickCell.bind(this);
     this.onSelectClue = this.onSelectClue.bind(this);
     this.keyDown = this.keyDown.bind(this);
     this.onInput = this.onInput.bind(this);
+    this.onDelete = this.onDelete.bind(this);
     this.openRebus = this.openRebus.bind(this);
     this.setPencil = this.setPencil.bind(this);
     this.doReveal = this.doReveal.bind(this);
@@ -99,7 +103,15 @@ export class PuzzleComponent extends React.Component<PuzzleProps, PuzzleState> {
     );
   }
 
+  // Opens free-text entry for the selected cell: on a touch screen,
+  // the on-screen keyboard's text box (which is sized for the device
+  // keyboard); otherwise, an input inside the cell itself.
   openRebus() {
+    const keyboard = this.keyboard.current;
+    if (keyboard && keyboard.isVisible()) {
+      keyboard.openEntry();
+      return;
+    }
     if (this.grid.current && this.grid.current.activeCell.current) {
       this.grid.current.activeCell.current.setState({ rebus: true });
     }
@@ -113,6 +125,12 @@ export class PuzzleComponent extends React.Component<PuzzleProps, PuzzleState> {
     this.updateGame((game) => Crossword.keypress(game, fill.toUpperCase()));
   }
 
+  onDelete() {
+    this.updateGame(Crossword.deleteKey);
+  }
+
+  // Physical-keyboard input. Letters (and any other printable
+  // character) fill the selected cell; the rest of the keys navigate.
   keyDown(e: KeyboardEvent) {
     if (!this.props.gameId) {
       return;
@@ -120,8 +138,10 @@ export class PuzzleComponent extends React.Component<PuzzleProps, PuzzleState> {
 
     const target = e.target;
     if (target instanceof HTMLElement) {
-      if (target.nodeName === "INPUT" && target.classList.contains("fill")) {
-        if (e.key === "Enter") {
+      // Typing into a text box (the in-cell rebus, or the keyboard's
+      // entry box) is the box's business, not the grid's.
+      if (target.nodeName === "INPUT" || target.nodeName === "TEXTAREA") {
+        if (e.key === "Enter" && target.classList.contains("fill")) {
           target.blur();
           e.preventDefault();
         }
@@ -161,10 +181,15 @@ export class PuzzleComponent extends React.Component<PuzzleProps, PuzzleState> {
       }
       case "Delete":
       case "Backspace":
-        this.updateGame(Crossword.deleteKey);
+        this.onDelete();
         break;
       default:
-        return;
+        // A single character is a printable key (named keys like
+        // "Shift" or "Dead" are longer). Spaces don't fill a cell.
+        if (e.key.length !== 1 || e.key === " ") {
+          return;
+        }
+        this.onInput(e.key);
     }
     e.preventDefault();
   }
@@ -340,13 +365,26 @@ export class PuzzleComponent extends React.Component<PuzzleProps, PuzzleState> {
           startGame={this.props.startGame}
         />
         {playing && (
-          <CurrentClue
-            clue={this.selectedClue()}
-            direction={this.direction()}
-            onPrev={this.prevClue}
-            onNext={this.nextClue}
-            onToggle={this.toggleDirection}
-          />
+          <div id="bottombar">
+            <CurrentClue
+              clue={this.selectedClue()}
+              direction={this.direction()}
+              onPrev={this.prevClue}
+              onNext={this.nextClue}
+              onToggle={this.toggleDirection}
+            />
+            {!solved && (
+              <Keyboard
+                ref={this.keyboard}
+                fill={
+                  Crossword.fillAt(this.state.game, this.state.game.cursor)
+                    ?.fill ?? ""
+                }
+                onInput={this.onInput}
+                onDelete={this.onDelete}
+              />
+            )}
+          </div>
         )}
         <PuzzleGrid
           ref={this.grid}

--- a/client/src/components/puzzle_grid.tsx
+++ b/client/src/components/puzzle_grid.tsx
@@ -17,16 +17,13 @@ export interface PuzzleGridProps {
 }
 
 export class PuzzleGrid extends React.Component<PuzzleGridProps> {
-  inputRef: React.RefObject<HTMLInputElement | null>;
   activeCell: React.RefObject<PuzzleCell | null>;
 
   constructor(props: PuzzleGridProps) {
     super(props);
-    this.inputRef = React.createRef();
     this.activeCell = React.createRef();
 
     this.onClick = this.onClick.bind(this);
-    this.onInput = this.onInput.bind(this);
   }
 
   onClick(evt: React.MouseEvent<HTMLDivElement>) {
@@ -37,29 +34,6 @@ export class PuzzleGrid extends React.Component<PuzzleGridProps> {
     const row = parseInt(target.dataset.row as string, 10);
     const column = parseInt(target.dataset.column as string, 10);
     this.props.onClickCell({ row: row, column: column });
-  }
-
-  onInput(e: React.FormEvent<HTMLInputElement>) {
-    if (!this.props.showCursor) {
-      return;
-    }
-    const target = e.target as HTMLInputElement;
-    const fill = target.value.toUpperCase();
-    this.props.onInput(fill);
-    target.value = "";
-    e.preventDefault();
-  }
-
-  componentDidMount() {
-    if (this.inputRef.current) {
-      this.inputRef.current.focus();
-    }
-  }
-
-  componentDidUpdate() {
-    if (this.inputRef.current) {
-      this.inputRef.current.focus();
-    }
   }
 
   render() {
@@ -118,27 +92,16 @@ export class PuzzleGrid extends React.Component<PuzzleGridProps> {
       "--puzzle-rows": this.props.game.puzzle.height,
     } as React.CSSProperties;
 
-    // In order to support mobile devices, we create an
-    // off-screen <input> field, which we ensure is always focused
-    // as long as the cursor is on a crossword cell. This forces
-    // mobile devices to pop up a keyboard, and we then listen for
-    // onInput events to catch keystrokes. We use a password field
-    // because that forces a letter-by-letter keyboard and input mode,
-    // avoiding potentially buffering input in the keyboard itself
-    // before it hits the DOM.
+    // Typing isn't handled here: keystrokes from a physical keyboard
+    // arrive via a window-level listener in PuzzleComponent, and touch
+    // devices get the on-screen Keyboard. The grid only takes input
+    // from the active cell's own rebus box.
     return (
       <div
         id="puzzlegrid"
         className={this.props.complete ? "complete" : undefined}
         style={style}
       >
-        <input
-          id="puzzleinput"
-          defaultValue=""
-          type="password"
-          onInput={this.onInput}
-          ref={this.inputRef}
-        />
         {cells}
       </div>
     );

--- a/client/src/components/style/puzzle.css
+++ b/client/src/components/style/puzzle.css
@@ -60,6 +60,12 @@
   display: none;
 }
 
+/* The on-screen keyboard is for touch screens; anyone on a wider
+   screen is assumed to have a real keyboard. */
+#keyboard {
+  display: none;
+}
+
 #theclue .label {
   background-color: #88f;
 }
@@ -105,17 +111,6 @@
   border-bottom: 1px solid black;
   padding: 0px;
   margin: 0px;
-}
-
-#puzzleinput {
-  width: 0;
-  height: 0;
-  padding: 0;
-  border: none;
-  position: fixed;
-  left: -10px;
-  top: -10px;
-  z-index: -1;
 }
 
 #puzzlegrid .cell.rebus .fill {
@@ -304,8 +299,9 @@
 
 /* Responsive layout, at two breakpoints:
 
-   - Below 768px ("mobile"): the clue box is hidden and the current
-     clue is pinned to the bottom of the screen.
+   - Below 768px ("mobile"): the clue box is hidden, and the current
+     clue and an on-screen keyboard are pinned to the bottom of the
+     screen.
    - At 992px and up ("wide"): the controls stack as a column beside
      the clue box. In between, they stay in a row, which wraps below
      the grid on its own when it runs out of room. */
@@ -321,16 +317,19 @@
     display: none;
   }
 
-  #theclue {
+  #bottombar {
     position: fixed;
     bottom: 0px;
     left: 0px;
     right: 0px;
     background-color: white;
     border-top: 2px solid black;
+    z-index: 5;
+  }
+
+  #theclue {
     padding: 10px 0px;
     margin: 0;
-    z-index: 5;
     display: flex;
     align-items: center;
   }
@@ -358,31 +357,123 @@
     background-color: #ccf;
   }
 
-  /* While the clue is pinned, scroll inside .App instead of the
+  #keyboard {
+    display: block;
+    --key-height: 42px;
+    padding: 5px 3px;
+    background-color: #d4d6db;
+    /* Selecting or long-pressing a key should behave like a keyboard,
+       not like text; and a touch that starts on the keyboard is a
+       keypress, never the start of a scroll (keys act on pointerdown). */
+    user-select: none;
+    -webkit-user-select: none;
+    -webkit-touch-callout: none;
+    touch-action: none;
+  }
+
+  /* Standard staggered QWERTY layout, on a 20-column grid: a letter
+     is two columns wide, so the 9-key middle row is inset by one
+     column (half a key) and the bottom row's two wide keys are three
+     columns each. */
+  #keyboard .keyrow {
+    display: grid;
+    grid-template-columns: repeat(20, 1fr);
+    gap: 5px 4px;
+    margin-bottom: 5px;
+  }
+
+  #keyboard .keyrow:last-child {
+    margin-bottom: 0;
+  }
+
+  #keyboard .keyrow:nth-child(2) .key:first-child {
+    grid-column: 2 / span 2;
+  }
+
+  #keyboard .key {
+    grid-column: span 2;
+    height: var(--key-height);
+    min-width: 0;
+    padding: 0;
+    border: none;
+    border-radius: 5px;
+    background-color: white;
+    box-shadow: 0 1px 0 #888;
+    color: black;
+    font-family: inherit;
+    font-size: 18px;
+    font-weight: bold;
+  }
+
+  #keyboard .key.entry,
+  #keyboard .key.delete {
+    grid-column: span 3;
+    background-color: #b3b7c0;
+  }
+
+  #keyboard .key.entry {
+    font-weight: normal;
+  }
+
+  #keyboard .key:active {
+    background-color: #ccf;
+  }
+
+  /* The free-text box that the "..." key opens, in place of the letter
+     keys. Its font must be at least 16px, or iOS zooms the page in
+     when the box takes focus. */
+  #keyboard .entrybox {
+    display: flex;
+    gap: 5px;
+    height: var(--key-height);
+  }
+
+  #keyboard .entrybox input {
+    flex: 1;
+    min-width: 0;
+    font-size: 18px;
+    text-transform: uppercase;
+    padding: 0 8px;
+    border: 1px solid #888;
+    border-radius: 5px;
+  }
+
+  #keyboard .entrybox button {
+    flex: none;
+    padding: 0 16px;
+    border: none;
+    border-radius: 5px;
+    background-color: #77f;
+    color: white;
+    font-size: 16px;
+  }
+
+  /* While the bottom bar is pinned, scroll inside .App instead of the
      document. Scrolling the document makes mobile browsers show and
-     hide the URL bar, resizing the viewport the fixed clue is
-     anchored to; the clue then jitters (and lets the puzzle peek
-     through underneath) while the browser re-anchors it. With the
-     document pinned, the browser chrome never moves. Scrolling .App
-     (rather than #puzzle) puts the nav bar inside the scroller, so
-     it scrolls away and frees its space while solving. */
-  body:has(#theclue) {
+     hide the URL bar, resizing the viewport the fixed bar is anchored
+     to; the bar then jitters (and lets the puzzle peek through
+     underneath) while the browser re-anchors it. With the document
+     pinned, the browser chrome never moves. Scrolling .App (rather
+     than #puzzle) puts the nav bar inside the scroller, so it scrolls
+     away and frees its space while solving. */
+  body:has(#bottombar) {
     height: 100dvh;
     overflow: hidden;
   }
 
-  body:has(#theclue) #root {
+  body:has(#bottombar) #root {
     height: 100%;
   }
 
-  body:has(#theclue) .App {
+  body:has(#bottombar) .App {
     height: 100%;
     overflow-y: auto;
     overscroll-behavior: contain;
   }
 
-  /* Room to scroll the bottom of the page up past the pinned clue. */
+  /* Room to scroll the bottom of the page up past the pinned bar:
+     the keyboard (three rows) plus a clue of a couple of lines. */
   #controls {
-    padding-bottom: 100px;
+    padding-bottom: 260px;
   }
 }


### PR DESCRIPTION
Mobile input used to work by keeping an off-screen password field
focused so the device keyboard would stay up. Replace that with our own
letters-only QWERTY keyboard, pinned under the current clue on small
screens: it takes much less of the screen than a device keyboard, and
lets the clue bar sit where the layout expects it.

Anything that isn't a letter -- a rebus, digits, punctuation -- goes
through the keyboard's "..." key, which swaps the keys for a text box
and so brings up the device keyboard for just that one entry. The
sidebar's Rebus button, and re-tapping a rebus cell, open the same box
when the keyboard is showing, since the in-cell input is too small for
a phone (iOS zooms in on it).

Letter keystrokes from a physical keyboard, which also used to arrive
through the hidden input, are now handled by the window-level keydown
listener alongside the navigation keys, so external keyboards keep
working on any device. Keystrokes aimed at any text box are left to
the box.

Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LW8cRvzmXt7oci4LaNkdPm