### PR TITLE
Cap the mobile clue box at two lines and scroll the rest

### DIFF
--- a/client/src/components/style/puzzle.css
+++ b/client/src/components/style/puzzle.css
@@ -334,9 +334,22 @@
     align-items: center;
   }
 
+  /* A long clue must not push the keyboard down or the grid off the
+     screen: cap the text at about two lines and scroll the rest. */
   #theclue .body {
     flex: 1;
     min-width: 0;
+    max-height: 3em; /* two lines at Bootstrap's 1.5 line-height */
+    overflow-y: auto;
+    overscroll-behavior: contain;
+  }
+
+  /* The text's vertical padding is invisible (no background) but
+     pokes out of the line box, which would make even a one-line clue
+     scrollable now that overflow is clipped. */
+  #theclue .body > .text {
+    padding-top: 0;
+    padding-bottom: 0;
   }
 
   #theclue .clue-nav {


### PR DESCRIPTION
A long clue in the pinned bottom bar grew the bar without limit,
pushing the on-screen keyboard down and the grid off the screen.
Give the clue body a two-line max height with internal scrolling.

The clue text's vertical padding, invisible but poking out of the
line box, would have made even a one-line clue scrollable once
overflow was clipped, so drop it on mobile.

Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Qbcu7sDz9jUEevaQmrRd6f