### PR TITLE
Cap the mobile clue box height and scroll long clues

### DIFF
--- a/client/src/components/style/puzzle.css
+++ b/client/src/components/style/puzzle.css
@@ -335,11 +335,14 @@
   }
 
   /* A long clue must not push the keyboard down or the grid off the
-     screen: cap the text at about two lines and scroll the rest. */
+     screen: cap the text at about two lines and scroll the rest. The
+     cap is a fraction over two lines so that a longer clue shows the
+     top half of a third line, a visible cue that there's more to
+     scroll. Sizes assume Bootstrap's 1.5 line-height. */
   #theclue .body {
     flex: 1;
     min-width: 0;
-    max-height: 3em; /* two lines at Bootstrap's 1.5 line-height */
+    max-height: calc(2.4 * 1.5em);
     overflow-y: auto;
     overscroll-behavior: contain;
   }


### PR DESCRIPTION
## Summary

On mobile, a long clue in the pinned bottom bar grew the bar without limit, pushing the on-screen keyboard down and the grid off the screen. This caps the clue body at about two lines and scrolls the rest within the box.

- Cap the clue body at 2.4 lines (`calc(2.4 * 1.5em)`, Bootstrap's line-height) with `overflow-y: auto`. The fraction over two lines means a longer clue shows the top half of its third line, a visible cue that there is more to scroll. Exactly 2¼ lines showed only a sliver of the tallest letters, so 2.4 was chosen after comparing 2.25, 2.4 and 2.5.
- `overscroll-behavior: contain` so reaching the end of the clue doesn't start scrolling the page behind the bar.
- Drop the clue text span's vertical padding on mobile. It was invisible (no background) but poked out of the line box, which would have made even a one-line clue scrollable by a couple of pixels once overflow was clipped. This needed a child selector to outrank the existing `#theclue .body > span` padding rule.

One- and two-line clues render exactly as before. Desktop layout is untouched; all rules are inside the existing `width < 768px` block.

## Test plan

- [x] Rendered the clue bar at a 390px viewport in headless Chromium with short, medium and long clues: a short clue has zero scrollable overflow; a long clue holds at two lines plus a partial third and scrolls to reveal the rest; the keyboard stays in place.
- [x] `prettier --check`, `eslint`, `tsc --noEmit` and `vitest run` (74 tests) pass in `client/`.
- [ ] Try on a real phone with a puzzle that has a multi-line clue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qbcu7sDz9jUEevaQmrRd6f

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qbcu7sDz9jUEevaQmrRd6f)_